### PR TITLE
fix(reaction_station): 清空工作流序列和参数避免重复执行

### DIFF
--- a/unilabos/devices/workstation/bioyond_studio/reaction_station.py
+++ b/unilabos/devices/workstation/bioyond_studio/reaction_station.py
@@ -543,7 +543,9 @@ class BioyondReactionStation(BioyondWorkstation):
         if not result:
             return self._create_error_result("创建任务失败", "create_order")
         
+        # 清空工作流序列和参数，防止下次执行时累积重复
         self.pending_task_params = []
+        self.clear_workflows()  
         
         # print(f"\n✅ 任务创建成功: {result}")
         # print(f"\n✅ 任务创建成功")


### PR DESCRIPTION
在创建任务后清空工作流序列和参数，防止下次执行时累积重复

## Summary by Sourcery

Bug Fixes:
- Invoke clear_workflows after task creation to clear workflow sequences and avoid accumulation leading to repeated runs