### PR TITLE
Workstation dev yb2扣电工站增加组装参数

### DIFF
--- a/unilabos/registry/devices/work_station.yaml
+++ b/unilabos/registry/devices/work_station.yaml
@@ -71,8 +71,11 @@ bettery_station_registry:
         feedback: {}
         goal: {}
         goal_default:
+          assembly_pressure: 4200
+          assembly_type: 7
           elec_num: null
           elec_use_num: null
+          elec_vol: 50
           file_path: D:\coin_cell_data
         handles: {}
         result: {}
@@ -82,10 +85,19 @@ bettery_station_registry:
             feedback: {}
             goal:
               properties:
+                assembly_pressure:
+                  default: 4200
+                  type: integer
+                assembly_type:
+                  default: 7
+                  type: integer
                 elec_num:
                   type: string
                 elec_use_num:
                   type: string
+                elec_vol:
+                  default: 50
+                  type: integer
                 file_path:
                   default: D:\coin_cell_data
                   type: string
@@ -271,7 +283,10 @@ bettery_station_registry:
         feedback: {}
         goal: {}
         goal_default:
+          assembly_pressure: null
+          assembly_type: null
           elec_use_num: null
+          elec_vol: null
         handles: {}
         result: {}
         schema:
@@ -280,10 +295,19 @@ bettery_station_registry:
             feedback: {}
             goal:
               properties:
+                assembly_pressure:
+                  type: string
+                assembly_type:
+                  type: string
                 elec_use_num:
+                  type: string
+                elec_vol:
                   type: string
               required:
               - elec_use_num
+              - elec_vol
+              - assembly_type
+              - assembly_pressure
               type: object
             result: {}
           required:


### PR DESCRIPTION
扣电驱动中增加多个组装参数，elec_vol:int=50, assembly_type:int=7, assembly_pressure:int=4200，更新驱动与注册表

## Summary by Sourcery

Introduce electrolyte volume, assembly type, and assembly pressure parameters into the coin cell assembly workflow

New Features:
- Expose elec_vol, assembly_type, and assembly_pressure parameters in func_pack_send_msg_cmd and func_allpack_cmd with default values

Enhancements:
- Add default values and schema definitions for elec_vol, assembly_type, and assembly_pressure in the workstation registry

Chores:
- Remove obsolete commented-out material handling test code