### PR TITLE
fix(yb3): 物料名称与模型对齐；YAML 去掉 BIOYOND_PolymerStation_ 前缀；修复 6StockCarri…

### DIFF
--- a/unilabos/registry/resources/bioyond/bottle_carriers.yaml
+++ b/unilabos/registry/resources/bioyond/bottle_carriers.yaml
@@ -1,130 +1,130 @@
-BIOYOND_PolymerStation_1BottleCarrier:
+1BottleCarrier:
   category:
   - bottle_carriers
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_1BottleCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_1BottleCarrier
+  description: 1BottleCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_1FlaskCarrier:
+1FlaskCarrier:
   category:
   - bottle_carriers
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_1FlaskCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_1FlaskCarrier
+  description: 1FlaskCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_6StockCarrier:
+6StockCarrier:
   category:
   - bottle_carriers
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_6StockCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_6StockCarrier
+  description: 6StockCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_6VialCarrier:
+6VialCarrier:
   category:
   - bottle_carriers
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_6VialCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_6VialCarrier
+  description: 6VialCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_6x5ml_DispensingVialCarrier:
+6x5ml_DispensingVialCarrier:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_6x5ml_DispensingVialCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_6x5ml_DispensingVialCarrier
+  description: 6x5ml_DispensingVialCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_6x20ml_DispensingVialCarrier:
+6x20ml_DispensingVialCarrier:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_6x20ml_DispensingVialCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_6x20ml_DispensingVialCarrier
+  description: 6x20ml_DispensingVialCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_6x_SmallSolutionBottleCarrier:
+6x_SmallSolutionBottleCarrier:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_6x_SmallSolutionBottleCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_6x_SmallSolutionBottleCarrier
+  description: 6x_SmallSolutionBottleCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_4x_LargeSolutionBottleCarrier:
+4x_LargeSolutionBottleCarrier:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_4x_LargeSolutionBottleCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_4x_LargeSolutionBottleCarrier
+  description: 4x_LargeSolutionBottleCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_6x_LargeDispenseHeadCarrier:
+6x_LargeDispenseHeadCarrier:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_6x_LargeDispenseHeadCarrier
     type: pylabrobot
-  description: BIOYOND_PolymerStation_6x_LargeDispenseHeadCarrier
+  description: 6x_LargeDispenseHeadCarrier
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_AdapterBlock:
+AdapterBlock:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_AdapterBlock
     type: pylabrobot
-  description: BIOYOND_PolymerStation_AdapterBlock
+  description: AdapterBlock
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-BIOYOND_PolymerStation_TipBox:
+TipBox:
   category:
   - yb3
   class:
     module: unilabos.resources.bioyond.bottle_carriers:BIOYOND_PolymerStation_TipBox
     type: pylabrobot
-  description: BIOYOND_PolymerStation_TipBox
+  description: TipBox
   handles: []
   icon: ''
   init_param_schema: {}

--- a/unilabos/registry/resources/bioyond/bottles.yaml
+++ b/unilabos/registry/resources/bioyond/bottles.yaml
@@ -1,4 +1,4 @@
-BIOYOND_PolymerStation_Liquid_Vial:
+Liquid_Vial:
   category:
   - bottles
   class:
@@ -8,7 +8,7 @@ BIOYOND_PolymerStation_Liquid_Vial:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Reagent_Bottle:
+Reagent_Bottle:
   category:
   - bottles
   class:
@@ -18,7 +18,7 @@ BIOYOND_PolymerStation_Reagent_Bottle:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Solid_Stock:
+Solid_Stock:
   category:
   - bottles
   class:
@@ -28,7 +28,7 @@ BIOYOND_PolymerStation_Solid_Stock:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Solid_Vial:
+Solid_Vial:
   category:
   - bottles
   class:
@@ -38,7 +38,7 @@ BIOYOND_PolymerStation_Solid_Vial:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Solution_Beaker:
+Solution_Beaker:
   category:
   - bottles
   class:
@@ -48,7 +48,7 @@ BIOYOND_PolymerStation_Solution_Beaker:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_100ml_Liquid_Bottle:
+100ml_Liquid_Bottle:
   category:
   - yb3
   class:
@@ -58,7 +58,7 @@ BIOYOND_PolymerStation_100ml_Liquid_Bottle:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Liquid_Bottle:
+Liquid_Bottle:
   category:
   - yb3
   class:
@@ -68,7 +68,7 @@ BIOYOND_PolymerStation_Liquid_Bottle:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_High_Viscosity_Liquid_Bottle:
+High_Viscosity_Liquid_Bottle:
   category:
   - yb3
   class:
@@ -78,7 +78,7 @@ BIOYOND_PolymerStation_High_Viscosity_Liquid_Bottle:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Large_Dispense_Head:
+Large_Dispense_Head:
   category:
   - yb3
   class:
@@ -88,7 +88,7 @@ BIOYOND_PolymerStation_Large_Dispense_Head:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_5ml_Dispensing_Vial:
+5ml_Dispensing_Vial:
   category:
   - yb3
   class:
@@ -98,7 +98,7 @@ BIOYOND_PolymerStation_5ml_Dispensing_Vial:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_20ml_Dispensing_Vial:
+20ml_Dispensing_Vial:
   category:
   - yb3
   class:
@@ -108,7 +108,7 @@ BIOYOND_PolymerStation_20ml_Dispensing_Vial:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Small_Solution_Bottle:
+Small_Solution_Bottle:
   category:
   - yb3
   class:
@@ -118,7 +118,7 @@ BIOYOND_PolymerStation_Small_Solution_Bottle:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Large_Solution_Bottle:
+Large_Solution_Bottle:
   category:
   - yb3
   class:
@@ -128,7 +128,7 @@ BIOYOND_PolymerStation_Large_Solution_Bottle:
   icon: ''
   init_param_schema: {}
   version: 1.0.0
-BIOYOND_PolymerStation_Pipette_Tip:
+Pipette_Tip:
   category:
   - yb3
   class:

--- a/unilabos/resources/bioyond/bottle_carriers.py
+++ b/unilabos/resources/bioyond/bottle_carriers.py
@@ -57,7 +57,7 @@ def BIOYOND_Electrolyte_6VialCarrier(name: str) -> BottleCarrier:
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_Electrolyte_6VialCarrier",
+        model="Electrolyte_6VialCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -95,7 +95,7 @@ def BIOYOND_Electrolyte_1BottleCarrier(name: str) -> BottleCarrier:
             resource_size_y=beaker_diameter,
             name_prefix=name,
         ),
-        model="BIOYOND_Electrolyte_1BottleCarrier",
+        model="Electrolyte_1BottleCarrier",
     )
     carrier.num_items_x = 1
     carrier.num_items_y = 1
@@ -144,7 +144,7 @@ def BIOYOND_PolymerStation_6StockCarrier(name: str) -> BottleCarrier:
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_6VialCarrier",
+        model="6StockCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -195,7 +195,7 @@ def BIOYOND_PolymerStation_6VialCarrier(name: str) -> BottleCarrier:
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_6VialCarrier",
+        model="6VialCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -236,7 +236,7 @@ def BIOYOND_PolymerStation_1BottleCarrier(name: str) -> BottleCarrier:
             resource_size_y=beaker_diameter,
             name_prefix=name,
         ),
-        model="BIOYOND_PolymerStation_1BottleCarrier",
+        model="1BottleCarrier",
     )
     carrier.num_items_x = 1
     carrier.num_items_y = 1
@@ -273,7 +273,7 @@ def BIOYOND_PolymerStation_1FlaskCarrier(name: str) -> BottleCarrier:
             resource_size_y=beaker_diameter,
             name_prefix=name,
         ),
-        model="BIOYOND_PolymerStation_1FlaskCarrier",
+        model="1FlaskCarrier",
     )
     carrier.num_items_x = 1
     carrier.num_items_y = 1
@@ -321,7 +321,7 @@ def BIOYOND_PolymerStation_6x5ml_DispensingVialCarrier(name: str) -> BottleCarri
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_6x5ml_DispensingVialCarrier",
+        model="6x5ml_DispensingVialCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -371,7 +371,7 @@ def BIOYOND_PolymerStation_6x20ml_DispensingVialCarrier(name: str) -> BottleCarr
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_6x20ml_DispensingVialCarrier",
+        model="6x20ml_DispensingVialCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -421,7 +421,7 @@ def BIOYOND_PolymerStation_6x_SmallSolutionBottleCarrier(name: str) -> BottleCar
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_6x_SmallSolutionBottleCarrier",
+        model="6x_SmallSolutionBottleCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -471,7 +471,7 @@ def BIOYOND_PolymerStation_4x_LargeSolutionBottleCarrier(name: str) -> BottleCar
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_4x_LargeSolutionBottleCarrier",
+        model="4x_LargeSolutionBottleCarrier",
     )
     carrier.num_items_x = 2
     carrier.num_items_y = 2
@@ -521,7 +521,7 @@ def BIOYOND_PolymerStation_6x_LargeDispenseHeadCarrier(name: str) -> BottleCarri
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_6x_LargeDispenseHeadCarrier",
+        model="6x_LargeDispenseHeadCarrier",
     )
     carrier.num_items_x = 3
     carrier.num_items_y = 2
@@ -560,7 +560,7 @@ def BIOYOND_PolymerStation_AdapterBlock(name: str) -> BottleCarrier:
             resource_size_y=adapter_diameter,
             name_prefix=name,
         ),
-        model="BIOYOND_PolymerStation_AdapterBlock",
+        model="AdapterBlock",
     )
     carrier.num_items_x = 1
     carrier.num_items_y = 1
@@ -608,7 +608,7 @@ def BIOYOND_PolymerStation_TipBox(name: str) -> BottleCarrier:
         size_y=carrier_size_y,
         size_z=carrier_size_z,
         sites=sites,
-        model="BIOYOND_PolymerStation_TipBox",
+        model="TipBox",
     )
     carrier.num_items_x = 12
     carrier.num_items_y = 8

--- a/unilabos/resources/bioyond/bottles.py
+++ b/unilabos/resources/bioyond/bottles.py
@@ -16,7 +16,7 @@ def BIOYOND_PolymerStation_Solid_Stock(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Solid_Stock",
+        model="Solid_Stock",
     )
 
 
@@ -34,7 +34,7 @@ def BIOYOND_PolymerStation_Solid_Vial(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Solid_Vial",
+        model="Solid_Vial",
     )
 
 
@@ -52,7 +52,7 @@ def BIOYOND_PolymerStation_Liquid_Vial(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Liquid_Vial",
+        model="Liquid_Vial",
     )
 
 
@@ -70,7 +70,7 @@ def BIOYOND_PolymerStation_Solution_Beaker(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Solution_Beaker",
+        model="Solution_Beaker",
     )
 
 
@@ -88,7 +88,7 @@ def BIOYOND_PolymerStation_Reagent_Bottle(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Reagent_Bottle",
+        model="Reagent_Bottle",
     )
 
 
@@ -106,7 +106,7 @@ def BIOYOND_PolymerStation_100ml_Liquid_Bottle(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_100ml_Liquid_Bottle",
+        model="100ml_Liquid_Bottle",
     )
 
 
@@ -124,7 +124,7 @@ def BIOYOND_PolymerStation_Liquid_Bottle(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Liquid_Bottle",
+        model="Liquid_Bottle",
     )
 
 
@@ -142,7 +142,7 @@ def BIOYOND_PolymerStation_High_Viscosity_Liquid_Bottle(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_High_Viscosity_Liquid_Bottle",
+        model="High_Viscosity_Liquid_Bottle",
     )
 
 
@@ -160,7 +160,7 @@ def BIOYOND_PolymerStation_Large_Dispense_Head(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Large_Dispense_Head",
+        model="Large_Dispense_Head",
     )
 
 
@@ -178,7 +178,7 @@ def BIOYOND_PolymerStation_5ml_Dispensing_Vial(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_5ml_Dispensing_Vial",
+        model="5ml_Dispensing_Vial",
     )
 
 
@@ -196,7 +196,7 @@ def BIOYOND_PolymerStation_20ml_Dispensing_Vial(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_20ml_Dispensing_Vial",
+        model="20ml_Dispensing_Vial",
     )
 
 
@@ -214,7 +214,7 @@ def BIOYOND_PolymerStation_Small_Solution_Bottle(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Small_Solution_Bottle",
+        model="Small_Solution_Bottle",
     )
 
 
@@ -232,7 +232,7 @@ def BIOYOND_PolymerStation_Large_Solution_Bottle(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Large_Solution_Bottle",
+        model="Large_Solution_Bottle",
     )
 
 
@@ -250,6 +250,6 @@ def BIOYOND_PolymerStation_Pipette_Tip(
         height=height,
         max_volume=max_volume,
         barcode=barcode,
-        model="BIOYOND_PolymerStation_Pipette_Tip",
+        model="Pipette_Tip",
     )
 


### PR DESCRIPTION
YAML 前端名移除 BIOYOND_PolymerStation_ 前缀
对齐 YAML class.module 与 Python 工厂函数

## Summary by Sourcery

Align resource naming by removing the BIOYOND_PolymerStation_ prefix from YAML registry entries and updating Python factory model parameters to match the new names.

Enhancements:
- Remove BIOYOND_PolymerStation_ prefix from all resource keys and descriptions in bioyond YAML registry files
- Update Python factory functions to use unprefixed model names consistent with YAML entries