### PR TITLE
1104_byxinyu

### DIFF
--- a/unilabos/devices/workstation/coin_cell_assembly/coin_cell_assembly.py
+++ b/unilabos/devices/workstation/coin_cell_assembly/coin_cell_assembly.py
@@ -138,7 +138,7 @@ class CoinCellAssemblyWorkstation(WorkstationBase):
 
         # 如果没有传入 deck，则创建标准配置的 deck
         if self.deck is None:
-            self.deck = CoincellDeck(size_x=1000, size_y=1000, size_z=900, origin=Coordinate(-100, -100, 0),setup=True)
+            self.deck = CoincellDeck(size_x=1000, size_y=1000, size_z=900, origin=Coordinate(-800, 0, 0),setup=True)
         else:
             # 如果传入了 deck 但还没有 setup，可以选择是否 setup
             if self.deck is not None and len(self.deck.children) == 0:

--- a/unilabos/registry/devices/coin_cell_workstation.yaml
+++ b/unilabos/registry/devices/coin_cell_workstation.yaml
@@ -502,7 +502,7 @@ coincellassemblyworkstation_device:
   config_info: []
   description: ''
   handles: []
-  icon: ''
+  icon: coin_cell_assembly_picture.webp
   init_param_schema:
     config:
       properties:


### PR DESCRIPTION
## Summary by Sourcery

Update coin cell assembly workstation configuration: adjust default deck origin and assign an icon in registry

Enhancements:
- Adjust default deck origin from (-100, -100, 0) to (-800, 0, 0) in CoincellDeck initialization
- Set the coin cell assembly workstation icon to 'coin_cell_assembly_picture.webp' in the device registry YAML