### PR TITLE
修改pymodbus和websocket的报送信息

### DIFF
--- a/unilabos/app/ws_client.py
+++ b/unilabos/app/ws_client.py
@@ -421,8 +421,7 @@ class MessageProcessor:
                     ssl_context = ssl_module.create_default_context()
 
                 ws_logger = logging.getLogger("websockets.client")
-                # ws_logger.setLevel(logging.INFO)
-                ws_logger.setLevel(logging.WARNING)  # 只显示警告和错误
+                # 日志级别已在 unilabos.utils.log 中统一配置为 WARNING
 
                 async with websockets.connect(
                     self.websocket_url,
@@ -1198,7 +1197,7 @@ class WebSocketClient(BaseCommunicationClient):
             },
         }
         self.message_processor.send_message(message)
-        logger.debug(f"[WebSocketClient] Device status published: {device_id}.{property_name}")
+        logger.trace(f"[WebSocketClient] Device status published: {device_id}.{property_name}")
 
     def publish_job_status(
         self, feedback_data: dict, item: QueueItem, status: str, return_info: Optional[dict] = None

--- a/unilabos/ros/nodes/presets/host_node.py
+++ b/unilabos/ros/nodes/presets/host_node.py
@@ -652,7 +652,7 @@ class HostNode(BaseROS2DeviceNode):
                         if bCreate:
                             self.lab_logger().trace(f"Status created: {device_id}.{property_name} = {msg.data}")
                         else:
-                            self.lab_logger().debug(f"Status updated: {device_id}.{property_name} = {msg.data}")
+                            self.lab_logger().trace(f"Status updated: {device_id}.{property_name} = {msg.data}")
 
     def send_goal(
         self,

--- a/unilabos/utils/log.py
+++ b/unilabos/utils/log.py
@@ -194,10 +194,15 @@ def configure_logger(loglevel=None):
     
     # 降低第三方库的日志级别，避免过多输出
     # pymodbus 库的日志太详细，设置为 WARNING
-    logging.getLogger('pymodbus').setLevel(TRACE_LEVEL)
-    logging.getLogger('pymodbus.logging').setLevel(TRACE_LEVEL)
-    logging.getLogger('pymodbus.logging.base').setLevel(TRACE_LEVEL)
-    logging.getLogger('pymodbus.logging.decoders').setLevel(TRACE_LEVEL)
+    logging.getLogger('pymodbus').setLevel(logging.WARNING)
+    logging.getLogger('pymodbus.logging').setLevel(logging.WARNING)
+    logging.getLogger('pymodbus.logging.base').setLevel(logging.WARNING)
+    logging.getLogger('pymodbus.logging.decoders').setLevel(logging.WARNING)
+    
+    # websockets 库的日志输出较多，设置为 WARNING
+    logging.getLogger('websockets').setLevel(logging.WARNING)
+    logging.getLogger('websockets.client').setLevel(logging.WARNING)
+    logging.getLogger('websockets.server').setLevel(logging.WARNING)
 
 
 # 配置日志系统


### PR DESCRIPTION
## Summary by Sourcery

Standardize logging configuration for external libraries and adjust internal log levels to improve log granularity and reduce verbosity

Enhancements:
- Configure pymodbus and websockets libraries to WARNING level in the central logger setup
- Remove redundant per-instance logging level setting in the websocket client handler
- Change internal device status and host node update log entries from DEBUG to TRACE