### PR TITLE
Fix warehouse mapping: use actual parent warehouse name instead of ha…

### DIFF
--- a/unilabos/devices/workstation/bioyond_studio/config.py
+++ b/unilabos/devices/workstation/bioyond_studio/config.py
@@ -8,8 +8,8 @@ import os
 # BioyondCellWorkstation 默认配置（包含所有必需参数）
 API_CONFIG = {
     # API 连接配置
-    # "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.1.143:44389"),#实机
-    "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.7.149:44388"),# 仿真机
+    "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.1.143:44389"),#实机
+    # "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.7.149:44388"),# 仿真机
     "api_key": os.getenv("BIOYOND_API_KEY", "8A819E5C"),
     "timeout": int(os.getenv("BIOYOND_TIMEOUT", "30")),
     


### PR DESCRIPTION
修复推拽上料，堆栈不对的bug

## Summary by Sourcery

Fix warehouse mapping by using actual parent warehouse name for drag-and-drop sample transfers, extend create_sample to accept and validate warehouse_name parameter with enhanced logging and error handling, and update default API host configuration

Bug Fixes:
- Use actual parent warehouse name in drag-and-drop sample transfers

Enhancements:
- Add warehouse_name parameter to create_sample with validation and detailed logging
- Improve error handling for missing warehouse or site codes

Chores:
- Swap simulated and real API host defaults in config