### PR TITLE
Update coin cell assembly and YB_YH materials configuration

### DIFF
--- a/unilabos/devices/workstation/coin_cell_assembly/YB_YH_materials.py
+++ b/unilabos/devices/workstation/coin_cell_assembly/YB_YH_materials.py
@@ -20,7 +20,7 @@ from pylabrobot.resources.utils import create_ordered_items_2d
 
 from unilabos.resources.battery.magazine import MagazineHolder_4_Cathode, MagazineHolder_6_Cathode, MagazineHolder_6_Anode, MagazineHolder_6_Battery
 from unilabos.resources.battery.bottle_carriers import YIHUA_Electrolyte_12VialCarrier
-
+from unilabos.resources.battery.electrodesheet import ElectrodeSheet
 
 
 

--- a/unilabos/devices/workstation/coin_cell_assembly/coin_cell_assembly.py
+++ b/unilabos/devices/workstation/coin_cell_assembly/coin_cell_assembly.py
@@ -791,7 +791,7 @@ class CoinCellAssemblyWorkstation(WorkstationBase):
         logger.debug(f"data_electrolyte_code: {data_electrolyte_code}")
         logger.debug(f"data_coin_cell_code: {data_coin_cell_code}")
         #接收完信息后，读取完毕标志位置True
-        liaopan3 = self.deck.get_resource("chengpindanjia")        
+        liaopan3 = self.deck.get_resource("成品弹夹")        
         #把物料解绑后放到另一盘上
         battery = ElectrodeSheet(name=f"battery_{self.coin_num_N}", size_x=14, size_y=14, size_z=2)
         battery._unilabos_state = {


### PR DESCRIPTION
## Summary by Sourcery

Update resource naming and materials configuration for coin cell assembly and YB_YH modules

Enhancements:
- Rename deck resource key from "chengpindanjia" to "成品弹夹" in coin_cell_assembly
- Revise YB_YH_materials configuration to reflect updated material codes and names