### PR TITLE
Fix import: change electrodesheet to electrode_sheet

### DIFF
--- a/unilabos/devices/workstation/coin_cell_assembly/coin_cell_assembly.py
+++ b/unilabos/devices/workstation/coin_cell_assembly/coin_cell_assembly.py
@@ -139,7 +139,7 @@ class CoinCellAssemblyWorkstation(WorkstationBase):
                 time.sleep(2)
             if not modbus_client.client.is_socket_open():
                 raise ValueError('modbus tcp connection failed')
-            self.nodes = BaseClient.load_csv(os.path.join(os.path.dirname(__file__), 'coin_cell_assembly_1105.csv'))
+            self.nodes = BaseClient.load_csv(os.path.join(os.path.dirname(__file__), 'coin_cell_assembly_a.csv'))
             self.client = modbus_client.register_node_list(self.nodes)
         else:
             print("测试模式，跳过连接")
@@ -1008,7 +1008,7 @@ class CoinCellAssemblyWorkstation(WorkstationBase):
             #     time.sleep(1)
             # time.sleep(40)
     # 数据读取与输出
-    def func_read_data_and_output(self, file_path: str="D:\\coin_cell_data"):
+    def func_read_data_and_output(self, file_path: str="/Users/sml/work"):
         # 检查CSV导出是否正在运行，已运行则跳出，防止同时启动两个while循环
         if self.csv_export_running:
             return False, "读取已在运行中"


### PR DESCRIPTION
修改路径

## Summary by Sourcery

Update hardcoded file paths in coin_cell_assembly module for CSV loading and data output

Enhancements:
- Load nodes from the updated CSV file 'coin_cell_assembly_a.csv' instead of 'coin_cell_assembly_1105.csv'
- Change the default output directory in func_read_data_and_output from a Windows path to '/Users/sml/work'