### PR TITLE
fix: 修复 BioyondCellWorkstation 和 CoinCellAssembly 工作流程

### DIFF
--- a/unilabos/devices/workstation/bioyond_studio/bioyond_cell/bioyond_cell_workstation.py
+++ b/unilabos/devices/workstation/bioyond_studio/bioyond_cell/bioyond_cell_workstation.py
@@ -257,7 +257,7 @@ class BioyondCellWorkstation(BioyondWorkstation):
     def auto_feeding4to3(
         self,
         # ★ 修改点：默认模板路径
-        xlsx_path: Optional[str] = "/Users/calvincao/Desktop/work/uni-lab-all/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/material_template.xlsx",
+        xlsx_path: Optional[str] = "/Users/sml/work/Unilab/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/material_template.xlsx",
         # ---------------- WH4 - 加样头面 (Z=1, 12个点位) ----------------
         WH4_x1_y1_z1_1_materialName: str = "", WH4_x1_y1_z1_1_quantity: float = 0.0,
         WH4_x2_y1_z1_2_materialName: str = "", WH4_x2_y1_z1_2_quantity: float = 0.0,
@@ -477,7 +477,7 @@ class BioyondCellWorkstation(BioyondWorkstation):
         - totalMass 自动计算为所有物料质量之和
         - createTime 缺失或为空时自动填充为当前日期（YYYY/M/D）
         """
-        default_path = Path("/Users/calvincao/Desktop/work/uni-lab-all/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/2025092701.xlsx")
+        default_path = Path("/Users/sml/work/Unilab/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/2025092701.xlsx")
         path = Path(xlsx_path) if xlsx_path else default_path
         print(f"[create_orders] 使用 Excel 路径: {path}")
         if path != default_path:
@@ -1165,137 +1165,39 @@ class BioyondCellWorkstation(BioyondWorkstation):
         })
         return final_result
 
-
-
-
-def run_bioyond_cell_workflow(config: Dict[str, Any]) -> BioyondCellWorkstation:
-    """按照统一配置执行奔曜配液与转运工作流。
-
-    Args:
-        config: 统一的工作流配置。字段示例:
-            {
-                "lab_registry": {"setup": True},
-                "deck": {"setup": True},
-                "workstation": {"config": {...}},
-                "update_push_ip": True,
-                "samples": [
-                    {"name": "...", "board_type": "...", "bottle_type": "...", "location_code": "...", "warehouse_name": "..."}
-                ],
-                "scheduler": {"start": True, "log": True},
-                "operations": {
-                    "auto_feeding4to3": {"enabled": True},
-                    "create_orders": {"excel_path": "...", "log": True},
-                    "transfer_3_to_2_to_1": {"enabled": True, "log": True},
-                    "transfer_1_to_2": {"enabled": True, "log": True}
-                },
-                "keep_alive": False,
-                "keep_alive_interval": 1
-            }
-
-    Returns:
-        执行完毕的 `BioyondCellWorkstation` 实例。
-    """
-
-    if config.get("lab_registry", {}).get("setup", True):
-        lab_registry.setup()
-
-    deck_config = config.get("deck")
-    if isinstance(deck_config, dict):
-        deck = BIOYOND_YB_Deck(**deck_config)
-    elif deck_config is None:
-        deck = BIOYOND_YB_Deck(setup=True)
-    else:
-        deck = deck_config
-
-    workstation_kwargs = dict(config.get("workstation", {}))
-    if "deck" not in workstation_kwargs:
-        workstation_kwargs["deck"] = deck
-    ws = BioyondCellWorkstation(**workstation_kwargs)
-
-    if config.get("update_push_ip", True):
-        ws.update_push_ip()
-
-    for sample_cfg in config.get("samples", []):
-        ws.create_sample(**sample_cfg)
-
-    scheduler_cfg = config.get("scheduler", {})
-    if scheduler_cfg.get("start", True):
-        result = ws.scheduler_start()
-        if scheduler_cfg.get("log", True):
-            logger.info(result)
-
-    operations_cfg = config.get("operations", {})
-
-    auto_feeding_cfg = operations_cfg.get("auto_feeding4to3", {})
-    if auto_feeding_cfg.get("enabled", True):
-        result = ws.auto_feeding4to3()
-        if auto_feeding_cfg.get("log", True):
-            logger.info(result)
-
-    create_orders_cfg = operations_cfg.get("create_orders")
-    if create_orders_cfg:
-        excel_path = create_orders_cfg.get("excel_path")
-        if not excel_path:
-            raise ValueError("create_orders 需要提供 excel_path。")
-        result = ws.create_orders(Path(excel_path))
-        if create_orders_cfg.get("log", True):
-            logger.info(result)
-
-    transfer_321_cfg = operations_cfg.get("transfer_3_to_2_to_1", {})
-    if transfer_321_cfg.get("enabled", True):
-        result = ws.transfer_3_to_2_to_1()
-        if transfer_321_cfg.get("log", True):
-            logger.info(result)
-
-    transfer_12_cfg = operations_cfg.get("transfer_1_to_2", {})
-    if transfer_12_cfg.get("enabled", True):
-        result = ws.transfer_1_to_2()
-        if transfer_12_cfg.get("log", True):
-            logger.info(result)
-
-    if config.get("keep_alive", False):
-        interval = config.get("keep_alive_interval", 1)
-        while True:
-            time.sleep(interval)
-
-    return ws
-
-
+    def run_bioyond_cell_workflow(self):
+        self.create_sample(
+            board_type="配液瓶(小)板",
+            bottle_type="配液瓶(小)",
+            location_code="B01",
+            name="配液瓶",
+            warehouse_name="手动堆栈"
+        )
+        self.create_sample(
+            board_type="5ml分液瓶板",
+            bottle_type="5ml分液瓶",
+            location_code="B02",
+            name="分液瓶",
+            warehouse_name="手动堆栈"
+        )
+        self.scheduler_start()
+        self.auto_feeding4to3(
+            xlsx_path="/Users/sml/work/Unilab/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/material_template.xlsx"
+        )
+        self.create_orders(
+            xlsx_path="/Users/sml/work/Unilab/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/2025092701.xlsx"
+        )
+        self.transfer_3_to_2_to_1(
+            source_wh_id="3a19debc-84b4-0359-e2d4-b3beea49348b",
+            source_x=1,
+            source_y=1,
+            source_z=1,
+        )
+        return self
 if __name__ == "__main__":
-    workflow_config = {
-        "deck": {"setup": True},
-        "update_push_ip": True,
-        "samples": [
-            {
-                "name": "配液瓶",
-                "board_type": "配液瓶(小)板",
-                "bottle_type": "配液瓶(小)",
-                "location_code": "E01",
-            },
-            {
-                "name": "分液瓶",
-                "board_type": "5ml分液瓶板",
-                "bottle_type": "5ml分液瓶",
-                "location_code": "D01",
-            },
-        ],
-        "operations": {
-            "auto_feeding4to3": {"enabled": True, "log": True},
-            "create_orders": {
-                "excel_path": "/Users/calvincao/Desktop/work/uni-lab-all/Uni-Lab-OS/unilabos/devices/workstation/bioyond_studio/bioyond_cell/2025092701.xlsx",
-                "log": True,
-            },
-            "transfer_3_to_2_to_1": {"enabled": True, "log": True},
-            "transfer_1_to_2": {"enabled": True, "log": True},
-        },
-        "keep_alive": True,
-    }
-    run_bioyond_cell_workflow(workflow_config)
-
-    # 1. location code
-    # 2. 实验文件
-    # 3. material template file
-
+    deck = BIOYOND_YB_Deck(setup=True)
+    w = BioyondCellWorkstation(deck=deck, address="172.16.28.102", port="502", debug_mode=False)
+    w.run_bioyond_cell_workflow()
     while True:
         time.sleep(1)
     # re=ws.scheduler_stop()

--- a/unilabos/devices/workstation/bioyond_studio/config.py
+++ b/unilabos/devices/workstation/bioyond_studio/config.py
@@ -8,8 +8,8 @@ import os
 # BioyondCellWorkstation 默认配置（包含所有必需参数）
 API_CONFIG = {
     # API 连接配置
-    "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.1.143:44389"),#实机
-    # "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.7.149:44388"),# 仿真机
+    # "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.1.143:44389"),#实机
+    "api_host": os.getenv("BIOYOND_API_HOST", "http://172.16.11.219:44388"),# 仿真机
     "api_key": os.getenv("BIOYOND_API_KEY", "8A819E5C"),
     "timeout": int(os.getenv("BIOYOND_TIMEOUT", "30")),
     
@@ -17,7 +17,7 @@ API_CONFIG = {
     "report_token": os.getenv("BIOYOND_REPORT_TOKEN", "CHANGE_ME_TOKEN"),
     
     # HTTP 服务配置
-    "HTTP_host": os.getenv("BIOYOND_HTTP_HOST", "172.16.2.140"),  # HTTP服务监听地址，监听计算机飞连ip地址
+    "HTTP_host": os.getenv("BIOYOND_HTTP_HOST", "172.16.11.2"),  # HTTP服务监听地址，监听计算机飞连ip地址
     "HTTP_port": int(os.getenv("BIOYOND_HTTP_PORT", "8080")),
     "debug_mode": False,# 调试模式
 }

--- a/unilabos/registry/devices/bioyond_cell.yaml
+++ b/unilabos/registry/devices/bioyond_cell.yaml
@@ -821,6 +821,27 @@ bioyond_cell:
           title: resource_tree_transfer参数
           type: object
         type: UniLabJsonCommand
+      auto-run_bioyond_cell_workflow:
+        feedback: {}
+        goal: {}
+        goal_default: {}
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties: {}
+              required: []
+              type: object
+            result: {}
+          required:
+          - goal
+          title: run_bioyond_cell_workflow参数
+          type: object
+        type: UniLabJsonCommand
       auto-scheduler_continue:
         feedback: {}
         goal: {}
@@ -1114,7 +1135,7 @@ bioyond_cell:
   config_info: []
   description: ''
   handles: []
-  icon: benyao2.webp
+  icon: ''
   init_param_schema:
     config:
       properties:

--- a/unilabos/registry/devices/coin_cell_workstation.yaml
+++ b/unilabos/registry/devices/coin_cell_workstation.yaml
@@ -79,7 +79,7 @@ coincellassemblyworkstation_device:
           elec_num: null
           elec_use_num: null
           elec_vol: 50
-          file_path: C:\Users\67484\Desktop
+          file_path: /Users/sml/work
         handles: {}
         placeholder_keys: {}
         result: {}
@@ -103,7 +103,7 @@ coincellassemblyworkstation_device:
                   default: 50
                   type: integer
                 file_path:
-                  default: C:\Users\67484\Desktop
+                  default: /Users/sml/work
                   type: string
               required:
               - elec_num
@@ -332,7 +332,7 @@ coincellassemblyworkstation_device:
         feedback: {}
         goal: {}
         goal_default:
-          file_path: D:\coin_cell_data
+          file_path: /Users/sml/work
         handles: {}
         placeholder_keys: {}
         result: {}
@@ -343,7 +343,7 @@ coincellassemblyworkstation_device:
             goal:
               properties:
                 file_path:
-                  default: D:\coin_cell_data
+                  default: /Users/sml/work
                   type: string
               required: []
               type: object
@@ -477,6 +477,52 @@ coincellassemblyworkstation_device:
           title: qiming_coin_cell_code参数
           type: object
         type: UniLabJsonCommand
+      auto-run_coin_cell_assembly_workflow:
+        feedback: {}
+        goal: {}
+        goal_default: {}
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties: {}
+              required: []
+              type: object
+            result: {}
+          required:
+          - goal
+          title: run_coin_cell_assembly_workflow参数
+          type: object
+        type: UniLabJsonCommand
+      auto-run_packaging_workflow:
+        feedback: {}
+        goal: {}
+        goal_default:
+          workflow_config: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                workflow_config:
+                  type: object
+              required:
+              - workflow_config
+              type: object
+            result: {}
+          required:
+          - goal
+          title: run_packaging_workflow参数
+          type: object
+        type: UniLabJsonCommand
     module: unilabos.devices.workstation.coin_cell_assembly.coin_cell_assembly:CoinCellAssemblyWorkstation
     status_types:
       data_assembly_coin_cell_num: int
@@ -500,20 +546,22 @@ coincellassemblyworkstation_device:
       sys_status: str
     type: python
   config_info: []
-  description: ''
+  description: 扣电工站
   handles: []
-  icon: koudian.webp
+  icon: ''
   init_param_schema:
     config:
       properties:
         address:
-          default: 172.21.32.111
+          default: 172.16.28.102
           type: string
+        config:
+          type: object
         debug_mode:
           default: false
           type: boolean
         deck:
-          type: object
+          type: string
         port:
           default: '502'
           type: string

--- a/unilabos/registry/devices/liquid_handler.yaml
+++ b/unilabos/registry/devices/liquid_handler.yaml
@@ -654,6 +654,31 @@ liquid_handler:
           title: iter_tips参数
           type: object
         type: UniLabJsonCommand
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: string
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       auto-set_group:
         feedback: {}
         goal: {}
@@ -6170,6 +6195,31 @@ liquid_handler.prcxi:
           title: move_to参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       auto-run_protocol:
         feedback: {}
         goal: {}

--- a/unilabos/registry/devices/neware_battery_test_system.yaml
+++ b/unilabos/registry/devices/neware_battery_test_system.yaml
@@ -5,6 +5,73 @@ neware_battery_test_system:
   - battery_test
   class:
     action_value_mappings:
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: string
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
+      auto-print_status_summary:
+        feedback: {}
+        goal: {}
+        goal_default: {}
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties: {}
+              required: []
+              type: object
+            result: {}
+          required:
+          - goal
+          title: print_status_summary参数
+          type: object
+        type: UniLabJsonCommand
+      auto-test_connection:
+        feedback: {}
+        goal: {}
+        goal_default: {}
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties: {}
+              required: []
+              type: object
+            result: {}
+          required:
+          - goal
+          title: test_connection参数
+          type: object
+        type: UniLabJsonCommand
       debug_resource_names:
         feedback: {}
         goal: {}
@@ -320,28 +387,24 @@ neware_battery_test_system:
     config:
       properties:
         devtype:
-          default: '27'
           type: string
         ip:
-          default: 127.0.0.1
           type: string
         machine_id:
           default: 1
           type: integer
         port:
-          default: 502
           type: integer
         size_x:
-          default: 50.0
+          default: 50
           type: number
         size_y:
-          default: 50.0
+          default: 50
           type: number
         size_z:
-          default: 20.0
+          default: 20
           type: number
         timeout:
-          default: 20
           type: integer
       required: []
       type: object

--- a/unilabos/registry/devices/virtual_device.yaml
+++ b/unilabos/registry/devices/virtual_device.yaml
@@ -45,6 +45,31 @@ virtual_centrifuge:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       centrifuge:
         feedback:
           current_speed: current_speed
@@ -335,6 +360,31 @@ virtual_column:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       run_column:
         feedback:
           current_status: current_status
@@ -732,6 +782,31 @@ virtual_filter:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       filter:
         feedback:
           current_status: current_status
@@ -1358,6 +1433,31 @@ virtual_heatchill:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       heat_chill:
         feedback:
           status: status
@@ -2358,6 +2458,31 @@ virtual_rotavap:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       evaporate:
         feedback:
           current_device: current_device
@@ -2690,6 +2815,31 @@ virtual_separator:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       separate:
         feedback:
           current_status: status
@@ -3600,6 +3750,31 @@ virtual_solenoid_valve:
           title: is_closed参数
           type: object
         type: UniLabJsonCommand
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       auto-reset:
         feedback: {}
         goal: {}
@@ -4177,6 +4352,31 @@ virtual_solid_dispenser:
           title: parse_mol_string参数
           type: object
         type: UniLabJsonCommand
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
     module: unilabos.devices.virtual.virtual_solid_dispenser:VirtualSolidDispenser
     status_types:
       current_reagent: str
@@ -4278,6 +4478,31 @@ virtual_stirrer:
           title: initialize参数
           type: object
         type: UniLabJsonCommandAsync
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
+          type: object
+        type: UniLabJsonCommand
       start_stir:
         feedback:
           status: status
@@ -4993,6 +5218,31 @@ virtual_transfer_pump:
           required:
           - goal
           title: is_full参数
+          type: object
+        type: UniLabJsonCommand
+      auto-post_init:
+        feedback: {}
+        goal: {}
+        goal_default:
+          ros_node: null
+        handles: {}
+        placeholder_keys: {}
+        result: {}
+        schema:
+          description: ''
+          properties:
+            feedback: {}
+            goal:
+              properties:
+                ros_node:
+                  type: object
+              required:
+              - ros_node
+              type: object
+            result: {}
+          required:
+          - goal
+          title: post_init参数
           type: object
         type: UniLabJsonCommand
       auto-pull_plunger:

--- a/unilabos/registry/resources/bioyond/YB_bottle.yaml
+++ b/unilabos/registry/resources/bioyond/YB_bottle.yaml
@@ -1,16 +1,3 @@
-YB_qiang_tou:
-  category:
-  - yb3
-  - YB_bottle
-  class:
-    module: unilabos.resources.bioyond.YB_bottles:YB_qiang_tou
-    type: pylabrobot
-  description: YB_qiang_tou
-  handles: []
-  icon: ''
-  init_param_schema: {}
-  registry_type: resource
-  version: 1.0.0
 YB_20ml_fenyeping:
   category:
   - yb3
@@ -32,6 +19,19 @@ YB_5ml_fenyeping:
     module: unilabos.resources.bioyond.YB_bottles:YB_5ml_fenyeping
     type: pylabrobot
   description: YB_5ml_fenyeping
+  handles: []
+  icon: ''
+  init_param_schema: {}
+  registry_type: resource
+  version: 1.0.0
+YB_jia_yang_tou_da:
+  category:
+  - yb3
+  - YB_bottle
+  class:
+    module: unilabos.resources.bioyond.YB_bottles:YB_jia_yang_tou_da
+    type: pylabrobot
+  description: YB_jia_yang_tou_da
   handles: []
   icon: ''
   init_param_schema: {}
@@ -63,14 +63,14 @@ YB_pei_ye_xiao_Bottle:
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-YB_jia_yang_tou_da:
+YB_qiang_tou:
   category:
   - yb3
   - YB_bottle
   class:
-    module: unilabos.resources.bioyond.YB_bottles:YB_jia_yang_tou_da
+    module: unilabos.resources.bioyond.YB_bottles:YB_qiang_tou
     type: pylabrobot
-  description: YB_jia_yang_tou_da
+  description: YB_qiang_tou
   handles: []
   icon: ''
   init_param_schema: {}
@@ -80,6 +80,7 @@ YB_ye_Bottle:
   category:
   - yb3
   - YB_bottle_carriers
+  - YB_bottle
   class:
     module: unilabos.resources.bioyond.YB_bottles:YB_ye_Bottle
     type: pylabrobot

--- a/unilabos/registry/resources/bioyond/YB_bottle_carriers.yaml
+++ b/unilabos/registry/resources/bioyond/YB_bottle_carriers.yaml
@@ -11,40 +11,27 @@ YB_100ml_yeti:
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-# YB_1BottleCarrier:
-#   category:
-#   - yb3
-#   - YB_bottle_carriers
-#   class:
-#     module: unilabos.resources.bioyond.YB_bottle_carriers:YB_1BottleCarrier
-#     type: pylabrobot
-#   description: YB_1BottleCarrier
-#   handles: []
-#   icon: ''
-#   init_param_schema: {}
-#   registry_type: resource
-#   version: 1.0.0
-YB_gaonianye:
+YB_20ml_fenyepingban:
   category:
   - yb3
   - YB_bottle_carriers
   class:
-    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_gaonianye
+    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_20ml_fenyepingban
     type: pylabrobot
-  description: YB_gaonianye
+  description: YB_20ml_fenyepingban
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-YB_peiyepingdaban:
+YB_5ml_fenyepingban:
   category:
   - yb3
   - YB_bottle_carriers
   class:
-    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_peiyepingdaban
+    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_5ml_fenyepingban
     type: pylabrobot
-  description: YB_peiyepingdaban
+  description: YB_5ml_fenyepingban
   handles: []
   icon: ''
   init_param_schema: {}
@@ -76,27 +63,53 @@ YB_6VialCarrier:
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-YB_20ml_fenyepingban:
+YB_gao_nian_ye_Bottle:
   category:
   - yb3
   - YB_bottle_carriers
   class:
-    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_20ml_fenyepingban
+    module: unilabos.resources.bioyond.YB_bottles:YB_gao_nian_ye_Bottle
     type: pylabrobot
-  description: YB_20ml_fenyepingban
+  description: YB_gao_nian_ye_Bottle
   handles: []
   icon: ''
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-YB_5ml_fenyepingban:
+YB_gaonianye:
   category:
   - yb3
   - YB_bottle_carriers
   class:
-    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_5ml_fenyepingban
+    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_gaonianye
     type: pylabrobot
-  description: YB_5ml_fenyepingban
+  description: YB_gaonianye
+  handles: []
+  icon: ''
+  init_param_schema: {}
+  registry_type: resource
+  version: 1.0.0
+YB_jia_yang_tou_da_Carrier:
+  category:
+  - yb3
+  - YB_bottle_carriers
+  class:
+    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_jia_yang_tou_da_Carrier
+    type: pylabrobot
+  description: YB_jia_yang_tou_da_Carrier
+  handles: []
+  icon: ''
+  init_param_schema: {}
+  registry_type: resource
+  version: 1.0.0
+YB_peiyepingdaban:
+  category:
+  - yb3
+  - YB_bottle_carriers
+  class:
+    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_peiyepingdaban
+    type: pylabrobot
+  description: YB_peiyepingdaban
   handles: []
   icon: ''
   init_param_schema: {}
@@ -115,19 +128,6 @@ YB_peiyepingxiaoban:
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-YB_shi_pei_qi_kuai:
-  category:
-  - yb3
-  - YB_bottle_carriers
-  class:
-    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_shi_pei_qi_kuai
-    type: pylabrobot
-  description: YB_shi_pei_qi_kuai
-  handles: []
-  icon: ''
-  init_param_schema: {}
-  registry_type: resource
-  version: 1.0.0
 YB_qiang_tou_he:
   category:
   - yb3
@@ -141,53 +141,14 @@ YB_qiang_tou_he:
   init_param_schema: {}
   registry_type: resource
   version: 1.0.0
-YB_gao_nian_ye_Bottle:
+YB_shi_pei_qi_kuai:
   category:
   - yb3
   - YB_bottle_carriers
   class:
-    module: unilabos.resources.bioyond.YB_bottles:YB_gao_nian_ye_Bottle
+    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_shi_pei_qi_kuai
     type: pylabrobot
-  description: YB_gao_nian_ye_Bottle
-  handles: []
-  icon: ''
-  init_param_schema: {}
-  registry_type: resource
-  version: 1.0.0
-# YB_jia_yang_tou_da:
-#   category:
-#   - yb3
-#   - YB_bottle_carriers
-#   class:
-#     module: unilabos.resources.bioyond.YB_bottles:YB_jia_yang_tou_da
-#     type: pylabrobot
-#   description: YB_jia_yang_tou_da
-#   handles: []
-#   icon: ''
-#   init_param_schema: {}
-#   registry_type: resource
-#   version: 1.0.0
-YB_jia_yang_tou_da_Carrier:
-  category:
-  - yb3
-  - YB_bottle_carriers
-  class:
-    module: unilabos.resources.bioyond.YB_bottle_carriers:YB_jia_yang_tou_da_Carrier
-    type: pylabrobot
-  description: YB_jia_yang_tou_da_Carrier
-  handles: []
-  icon: ''
-  init_param_schema: {}
-  registry_type: resource
-  version: 1.0.0
-YB_ye_100ml_Bottle:
-  category:
-  - yb3
-  - YB_bottle_carriers
-  class:
-    module: unilabos.resources.bioyond.YB_bottles:YB_ye_100ml_Bottle
-    type: pylabrobot
-  description: YB_ye_100ml_Bottle
+  description: YB_shi_pei_qi_kuai
   handles: []
   icon: ''
   init_param_schema: {}
@@ -201,6 +162,19 @@ YB_ye:
     module: unilabos.resources.bioyond.YB_bottle_carriers:YB_ye
     type: pylabrobot
   description: YB_ye_Bottle_Carrier
+  handles: []
+  icon: ''
+  init_param_schema: {}
+  registry_type: resource
+  version: 1.0.0
+YB_ye_100ml_Bottle:
+  category:
+  - yb3
+  - YB_bottle_carriers
+  class:
+    module: unilabos.resources.bioyond.YB_bottles:YB_ye_100ml_Bottle
+    type: pylabrobot
+  description: YB_ye_100ml_Bottle
   handles: []
   icon: ''
   init_param_schema: {}


### PR DESCRIPTION
简化工作流函数

## Summary by Sourcery

Simplify and standardize Bioyond cell and coin-cell workflows while extending device/resource registries with new auto workflow commands and updated defaults.

New Features:
- Add instance-level workflow runner methods for BioyondCellWorkstation and CoinCellAssemblyWorkstation to execute typical end-to-end workflows with predefined parameters.
- Expose new auto workflow commands (e.g. run_bioyond_cell_workflow, run_coin_cell_assembly_workflow, run_packaging_workflow) and post-init/test utilities in device registry YAMLs for orchestration.
- Register additional Bioyond bottle and carrier resource types and adjust category mappings for better modeling of lab hardware.

Bug Fixes:
- Align registry and device defaults (file paths, IP/port, CSV mapping file) with the current deployment and data layout to prevent misconfigured runs.

Enhancements:
- Add generic auto-post_init actions to multiple virtual and liquid handler devices to support standardized initialization via JSON commands.
- Refine Neware battery test system configuration schema with clearer size defaults and without hard-coded connection defaults.
- Simplify main entrypoints for Bioyond cell and coin-cell scripts to construct decks/workstations directly and invoke the new workflow helpers.
- Improve coin cell workstation metadata (description, icon, init schema) for clearer configuration in the registry.