### PR TITLE
解决前端物料显示问题

### DIFF
--- a/unilabos/resources/graphio.py
+++ b/unilabos/resources/graphio.py
@@ -674,10 +674,15 @@ def resource_bioyond_to_plr(bioyond_materials: list[dict], type_mapping: Dict[st
             for loc in material.get("locations", []):
                 if hasattr(deck, "warehouses") and loc.get("whName") in deck.warehouses:
                     warehouse = deck.warehouses[loc["whName"]]
+                    num_x = getattr(warehouse, "num_items_x", 0) or 0
+                    num_y = getattr(warehouse, "num_items_y", 0) or 0
+                    num_z = getattr(warehouse, "num_items_z", 0) or 0
+                    if num_x <= 0 or num_y <= 0 or num_z <= 0:
+                        continue
                     idx = (
-                        (loc.get("y", 0) - 1) * warehouse.num_items_x * warehouse.num_items_y
-                        + (loc.get("x", 0) - 1) * warehouse.num_items_x
-                        + (loc.get("z", 0) - 1)
+                        (loc.get("z", 0) - 1) * num_x * num_y
+                        + (loc.get("y", 0) - 1) * num_x
+                        + (loc.get("x", 0) - 1)
                     )
                     if 0 <= idx < warehouse.capacity:
                         if warehouse[idx] is None or isinstance(warehouse[idx], ResourceHolder):


### PR DESCRIPTION
解决前端物料显示问题

## Summary by Sourcery

Adjust BIOYOND cell workstation integration and resource mapping to fix front-end material display and expose more detailed feeding task information.

New Features:
- Introduce a dedicated device class wrapper that normalizes BIOYOND deck type and category during deserialization.
- Return feeding task details, including items and task metadata, from the feeding stage workflow for downstream consumers.

Bug Fixes:
- Correct warehouse position indexing order and guard against invalid warehouse dimensions when mapping BIOYOND materials to PLR resources to fix incorrect material placement and display.

Enhancements:
- Extend the feeding stage workflow result schema to include both materials and feeding task information instead of only materials.