### PR TITLE
Fix startup json for 9320

### DIFF
--- a/unilabos/test/experiments/prcxi_9320_with_res_test.json
+++ b/unilabos/test/experiments/prcxi_9320_with_res_test.json
@@ -812,7 +812,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300TipRack",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -6515,7 +6515,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -10587,7 +10587,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300TipRack",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -16291,7 +16291,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -20365,7 +20365,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -24438,7 +24438,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -28512,7 +28512,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -32585,7 +32585,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,
@@ -36658,7 +36658,7 @@
                 "z": 0
             },
             "config": {
-                "type": "PRCXI9300Container",
+                "type": "PRCXI9300Plate",
                 "size_x": 127,
                 "size_y": 85.5,
                 "size_z": 10,


### PR DESCRIPTION
Enhance PRCXI9300 classes with new Container and TipRack implementations, improving state management and initialization logic. Update JSON configuration to reflect type changes for containers and plates.

## Summary by Sourcery

Refine PRCXI 9300 labware handling to better support JSON-driven initialization and state persistence for containers, plates, tip racks, and tube racks.

New Features:
- Introduce a PRCXI9300Container type for PRCXI 9300 deck slots with custom state serialization.

Enhancements:
- Improve PRCXI9300Plate, PRCXI9300TipRack, and tube rack constructors to handle both object-based and string-based ordering from JSON while maintaining backward compatibility with existing parameters.
- Ensure labware state and material metadata are preserved and merged correctly during serialization.

Tests:
- Update the PRCXI 9320 JSON experiment fixture to align with the new labware configuration and type handling.