### PR TITLE
feat: 支持阿尔泰科技DAM3000M系列控制仪表

### DIFF
--- a/unilabos/devices/altai_dam/__init__.py
+++ b/unilabos/devices/altai_dam/__init__.py
@@ -1,0 +1,12 @@
+"""
+阿尔泰科技DAM3000M系列控制仪表设备支持
+
+支持的设备:
+- DAM3060V: 4通道模拟输出模块
+- DAM3151: 32通道模拟输入模块
+"""
+
+from unilabos.devices.altai_dam.dam3060v import DAM3060V
+from unilabos.devices.altai_dam.dam3151 import DAM3151
+
+__all__ = ["DAM3060V", "DAM3151"]

--- a/unilabos/devices/altai_dam/dam3060v.py
+++ b/unilabos/devices/altai_dam/dam3060v.py
@@ -1,0 +1,159 @@
+"""
+DAM3060V - 4通道模拟输出模块
+
+输出范围:
+- Mode 0: -10V ~ 10V (range_code=9)
+- Mode 1: -5V ~ 5V (range_code=8)
+- Mode 2: 0V ~ 10V (range_code=14)
+- Mode 3: 0V ~ 5V (range_code=13)
+"""
+
+from math import ceil
+from typing import Tuple, Dict
+import ctypes
+from ctypes import wintypes
+
+from unilabos.devices.altai_dam.dam_base import DAMDeviceBase
+
+
+class DAM3060V(DAMDeviceBase):
+    """
+    DAM3060V - 4通道模拟输出模块
+    
+    每个通道可独立设置输出范围和输出电压
+    """
+    
+    # 设备参数
+    AOAddr = 352  # 模拟输出寄存器起始地址
+    RangeAddr = 272  # 量程设置寄存器起始地址
+    ChannelNum = 4  # 通道数
+    RangeNum = 4  # 量程模式数
+    ChannelAddr = 2  # 通道地址间隔
+    
+    # 量程模式映射 (range_code: (最小值, 最大值))
+    RangeModes: Dict[int, Tuple[float, float]] = {
+        9: (-10.0, 10.0),   # Mode 0: -10V to 10V
+        8: (-5.0, 5.0),     # Mode 1: -5V to 5V
+        14: (0.0, 10.0),    # Mode 2: 0V to 10V
+        13: (0.0, 5.0)      # Mode 3: 0V to 5V
+    }
+    
+    # 默认量程模式 (每个通道)
+    DefaultModeList = [8, 8, 8, 8]  # 默认全部为 -5V ~ 5V
+    
+    def __init__(self, com_id: int, baud_rate: int, device_id: int, 
+                 mode_list: list = None, dll_path: str = None):
+        """
+        初始化DAM3060V模块
+        
+        Args:
+            com_id: 串口号
+            baud_rate: 波特率代码
+            device_id: 设备ID
+            mode_list: 各通道量程模式列表 (长度为4，元素为range_code)
+            dll_path: DLL文件路径
+        """
+        super().__init__(com_id, baud_rate, device_id, dll_path)
+        
+        # 初始化通道量程模式
+        self.channel_modes = {}
+        mode_list = mode_list or self.DefaultModeList
+        
+        # 设置各通道量程
+        for channel in range(self.ChannelNum):
+            self.set_output_range_mode(channel, mode_list[channel])
+    
+    def set_output_range_mode(self, channel: int, range_code: int):
+        """
+        设置通道输出范围模式
+        
+        Args:
+            channel: 通道号 (0-3)
+            range_code: 量程代码 (8, 9, 13, 14)
+        
+        Raises:
+            ValueError: 参数错误
+            RuntimeError: 设置失败
+        """
+        if channel not in range(self.ChannelNum):
+            raise ValueError(f"通道号必须在 0-{self.ChannelNum-1} 之间")
+        
+        if range_code not in self.RangeModes:
+            raise ValueError(f"量程代码必须是 {list(self.RangeModes.keys())} 之一")
+        
+        reg_addr = self.RangeAddr + channel
+        if not self.write_single_reg(reg_addr, range_code):
+            raise RuntimeError(
+                f"设置量程失败: handle={self.handle}, device_id={self.device_id}, "
+                f"addr={reg_addr}, mode={range_code}"
+            )
+        
+        self.channel_modes[channel] = range_code
+    
+    def set_analog_output(self, channel: int, voltage: float):
+        """
+        设置模拟输出电压
+        
+        Args:
+            channel: 通道号 (0-3)
+            voltage: 输出电压 (V)
+        
+        Raises:
+            ValueError: 参数错误或电压超出范围
+            RuntimeError: 设置失败
+        """
+        if channel not in range(self.ChannelNum):
+            raise ValueError(f"通道号必须在 0-{self.ChannelNum-1} 之间")
+        
+        if channel not in self.channel_modes:
+            raise ValueError(f"通道 {channel} 尚未设置量程模式")
+        
+        range_code = self.channel_modes[channel]
+        range_bottom, range_top = self.RangeModes[range_code]
+        
+        # 检查电压范围
+        if not (range_bottom <= voltage <= range_top):
+            raise ValueError(
+                f"电压 {voltage}V 超出范围 [{range_bottom}V, {range_top}V]"
+            )
+        
+        # 计算数字值 (12位精度)
+        dal_lsb = ceil((voltage - range_bottom) * 0xFFF / (range_top - range_bottom))
+        
+        # 写入输出值
+        reg_addr = self.AOAddr + channel * self.ChannelAddr
+        
+        # 使用写多寄存器 (UInt32)
+        self._dam3000m.DAM3000M_WriteMultiRegsUInt32.argtypes = [
+            wintypes.HANDLE, wintypes.LONG, wintypes.LONG,
+            wintypes.LONG, ctypes.POINTER(wintypes.ULONG)
+        ]
+        self._dam3000m.DAM3000M_WriteMultiRegsUInt32.restype = wintypes.BOOL
+        
+        if not self._dam3000m.DAM3000M_WriteMultiRegsUInt32(
+            self.handle, self.device_id, reg_addr, 1,
+            ctypes.byref(ctypes.c_ulong(dal_lsb))
+        ):
+            raise RuntimeError(f"设置模拟输出失败: 通道 {channel}, 电压 {voltage}V")
+    
+    def get_range_mode(self, channel: int) -> Tuple[float, float]:
+        """
+        获取通道的当前量程范围
+        
+        Args:
+            channel: 通道号 (0-3)
+        
+        Returns:
+            (最小电压, 最大电压) 元组
+        """
+        if channel not in self.channel_modes:
+            raise ValueError(f"通道 {channel} 尚未设置量程模式")
+        
+        return self.RangeModes[self.channel_modes[channel]]
+    
+    def get_all_channels_range(self) -> Dict[int, Tuple[float, float]]:
+        """获取所有通道的量程范围"""
+        return {
+            channel: self.RangeModes[mode]
+            for channel, mode in self.channel_modes.items()
+        }

--- a/unilabos/devices/altai_dam/dam3151.py
+++ b/unilabos/devices/altai_dam/dam3151.py
@@ -1,0 +1,228 @@
+"""
+DAM3151 - 32通道模拟输入模块
+
+测量范围:
+电压:
+- -10V ~ 10V (range_code=9)
+- -5V ~ 5V (range_code=8)
+- -1V ~ 1V (range_code=6)
+- -500mV ~ 500mV (range_code=5)
+- -150mV ~ 150mV (range_code=4)
+- 0V ~ 10V (range_code=14)
+- 0V ~ 5V (range_code=13)
+- 1V ~ 5V (range_code=130)
+
+电流:
+- -20mA ~ 20mA (range_code=10)
+- 0mA ~ 20mA (range_code=11)
+- 4mA ~ 20mA (range_code=12)
+- 0mA ~ 22mA (range_code=128)
+"""
+
+from typing import Tuple, Dict, List
+import ctypes
+from ctypes import wintypes
+
+from unilabos.devices.altai_dam.dam_base import DAMDeviceBase
+
+
+class DAM3151(DAMDeviceBase):
+    """
+    DAM3151 - 32通道模拟输入模块
+    
+    支持32通道同步采集，可测量电压或电流信号
+    """
+    
+    # 设备参数
+    ChannelNum = 32  # 通道数
+    RangeNum = 12  # 量程模式数
+    RangeAddr = 136  # 量程设置寄存器起始地址 (137-1)
+    CHEnableAddr = 221  # 通道使能寄存器地址
+    ADAddr = 0  # A/D转换数据起始地址
+    fLsbType = 65535.0  # LSB转换系数
+    
+    # 量程模式映射 (range_code: (最小值, 最大值, 单位))
+    RangeModes: Dict[int, Tuple[float, float, str]] = {
+        9: (-10.0, 10.0, "V"),      # -10V to 10V
+        8: (-5.0, 5.0, "V"),        # -5V to 5V
+        6: (-1.0, 1.0, "V"),        # -1V to 1V
+        5: (-0.5, 0.5, "V"),        # -500mV to 500mV
+        4: (-0.15, 0.15, "V"),      # -150mV to 150mV
+        14: (0.0, 10.0, "V"),       # 0V to 10V
+        13: (0.0, 5.0, "V"),        # 0V to 5V
+        130: (1.0, 5.0, "V"),       # 1V to 5V
+        10: (-20.0, 20.0, "mA"),    # -20mA to 20mA
+        11: (0.0, 20.0, "mA"),      # 0mA to 20mA
+        12: (4.0, 20.0, "mA"),      # 4mA to 20mA
+        128: (0.0, 22.0, "mA")      # 0mA to 22mA
+    }
+    
+    # 默认量程模式 (交替使用电流和电压模式)
+    DefaultModeList = [10 if i % 2 == 0 else 8 for i in range(ChannelNum)]
+    
+    def __init__(self, com_id: int, baud_rate: int, device_id: int,
+                 mode_list: list = None, dll_path: str = None):
+        """
+        初始化DAM3151模块
+        
+        Args:
+            com_id: 串口号
+            baud_rate: 波特率代码
+            device_id: 设备ID
+            mode_list: 各通道量程模式列表 (长度为32，元素为range_code)
+            dll_path: DLL文件路径
+        """
+        super().__init__(com_id, baud_rate, device_id, dll_path)
+        
+        # 初始化通道量程模式
+        self.channel_modes = {}
+        mode_list = mode_list or self.DefaultModeList
+        
+        # 使能所有通道
+        self._enable_all_channels()
+        
+        # 设置各通道量程
+        for channel in range(self.ChannelNum):
+            self.set_measurement_range_mode(channel, mode_list[channel])
+    
+    def _enable_all_channels(self):
+        """使能所有32个通道"""
+        mask = (1 << self.ChannelNum) - 1  # 0xFFFFFFFF
+        if not self.write_single_reg(self.CHEnableAddr, mask):
+            raise RuntimeError(
+                f"使能通道失败: handle={self.handle}, device_id={self.device_id}, "
+                f"addr={self.CHEnableAddr}"
+            )
+    
+    def set_measurement_range_mode(self, channel: int, range_code: int):
+        """
+        设置通道测量范围模式
+        
+        Args:
+            channel: 通道号 (0-31)
+            range_code: 量程代码
+        
+        Raises:
+            ValueError: 参数错误
+            RuntimeError: 设置失败
+        """
+        if channel not in range(self.ChannelNum):
+            raise ValueError(f"通道号必须在 0-{self.ChannelNum-1} 之间")
+        
+        if range_code not in self.RangeModes:
+            raise ValueError(f"量程代码必须是 {list(self.RangeModes.keys())} 之一")
+        
+        reg_addr = self.RangeAddr + channel
+        if not self.write_single_reg(reg_addr, range_code):
+            raise RuntimeError(
+                f"设置量程失败: handle={self.handle}, device_id={self.device_id}, "
+                f"addr={reg_addr}, mode={range_code}"
+            )
+        
+        self.channel_modes[channel] = range_code
+    
+    def _data_converter(self, raw_data: int, range_top: float, range_bottom: float) -> float:
+        """
+        将原始数据转换为实际测量值
+        
+        Args:
+            raw_data: 原始A/D转换值
+            range_top: 量程上限
+            range_bottom: 量程下限
+        
+        Returns:
+            实际测量值 (V 或 mA)
+        """
+        return raw_data / self.fLsbType * (range_top - range_bottom) + range_bottom
+    
+    def measure_all_channels(self) -> List[float]:
+        """
+        测量所有32个通道
+        
+        Returns:
+            测量值列表 (长度为32，单位为 V 或 mA)
+        """
+        # 读取所有通道数据
+        raw_data = self.read_input_regs_uint16(self.ADAddr, self.ChannelNum)
+        
+        # 转换为实际值
+        measurements = []
+        for channel in range(self.ChannelNum):
+            if channel not in self.channel_modes:
+                measurements.append(None)
+                continue
+            
+            range_code = self.channel_modes[channel]
+            range_bottom, range_top, unit = self.RangeModes[range_code]
+            
+            value = self._data_converter(raw_data[channel], range_top, range_bottom)
+            measurements.append(value)
+        
+        return measurements
+    
+    def measure_channel(self, channel: int) -> float:
+        """
+        测量单个通道
+        
+        Args:
+            channel: 通道号 (0-31)
+        
+        Returns:
+            测量值 (V 或 mA)
+        """
+        if channel not in range(self.ChannelNum):
+            raise ValueError(f"通道号必须在 0-{self.ChannelNum-1} 之间")
+        
+        if channel not in self.channel_modes:
+            raise ValueError(f"通道 {channel} 尚未设置量程模式")
+        
+        # 读取单个通道数据
+        raw_data = self.read_input_regs_uint16(self.ADAddr + channel, 1)[0]
+        
+        # 转换为实际值
+        range_code = self.channel_modes[channel]
+        range_bottom, range_top, unit = self.RangeModes[range_code]
+        
+        return self._data_converter(raw_data, range_top, range_bottom)
+    
+    def get_range_mode(self, channel: int) -> Tuple[float, float, str]:
+        """
+        获取通道的当前量程范围
+        
+        Args:
+            channel: 通道号 (0-31)
+        
+        Returns:
+            (最小值, 最大值, 单位) 元组
+        """
+        if channel not in self.channel_modes:
+            raise ValueError(f"通道 {channel} 尚未设置量程模式")
+        
+        return self.RangeModes[self.channel_modes[channel]]
+    
+    def get_all_channels_range(self) -> Dict[int, Tuple[float, float, str]]:
+        """获取所有通道的量程范围"""
+        return {
+            channel: self.RangeModes[mode]
+            for channel, mode in self.channel_modes.items()
+        }
+    
+    def measure_current_channels(self) -> List[float]:
+        """
+        测量所有电流模式通道 (偶数通道)
+        
+        Returns:
+            电流值列表 (mA)
+        """
+        all_data = self.measure_all_channels()
+        return [all_data[i] for i in range(0, self.ChannelNum, 2)]
+    
+    def measure_voltage_channels(self) -> List[float]:
+        """
+        测量所有电压模式通道 (奇数通道)
+        
+        Returns:
+            电压值列表 (V)
+        """
+        all_data = self.measure_all_channels()
+        return [all_data[i] for i in range(1, self.ChannelNum, 2)]

--- a/unilabos/devices/altai_dam/dam_base.py
+++ b/unilabos/devices/altai_dam/dam_base.py
@@ -1,0 +1,163 @@
+"""
+阿尔泰科技DAM3000M系列设备基类
+"""
+
+import ctypes
+from ctypes import wintypes
+from typing import Dict, Optional
+import platform
+
+
+class DeviceInfo(ctypes.Structure):
+    """设备信息结构体"""
+    _fields_ = [
+        ("DeviceType", wintypes.LONG),
+        ("TypeSuffix", wintypes.LONG),
+        ("ModusType", wintypes.LONG),
+        ("VesionID", wintypes.LONG),
+        ("DeviceID", wintypes.LONG),
+        ("BaudRate", wintypes.LONG),
+        ("bParity", wintypes.LONG)
+    ]
+
+
+class DAMDeviceBase:
+    """
+    阿尔泰DAM3000M系列设备基类
+    
+    提供基本的设备连接、初始化和通信功能
+    """
+    
+    # 类级别的句柄缓存，支持同一串口共享句柄
+    _handles: Dict[int, wintypes.HANDLE] = {}
+    
+    def __init__(self, com_id: int, baud_rate: int, device_id: int, dll_path: Optional[str] = None):
+        """
+        初始化DAM设备
+        
+        Args:
+            com_id: 串口号 (例如: 4 表示 COM4)
+            baud_rate: 波特率代码 (0-7)
+                0: 1200 bps
+                1: 2400 bps
+                2: 4800 bps
+                3: 9600 bps
+                4: 19200 bps
+                5: 38400 bps
+                6: 57600 bps
+                7: 115200 bps
+            device_id: 设备ID (Modbus地址)
+            dll_path: DLL文件路径 (可选，默认为当前目录下的DAM3000M_64.dll)
+        """
+        if platform.system() != "Windows":
+            raise RuntimeError("阿尔泰DAM3000M设备仅支持Windows系统")
+        
+        self.com_id = com_id
+        self.baud_rate = baud_rate
+        self.device_id = device_id
+        self.dll_path = dll_path or "./DAM3000M_64.dll"
+        
+        # 加载DLL
+        self._dam3000m = ctypes.WinDLL(self.dll_path)
+        self._setup_dll_functions()
+        
+        # 获取设备句柄
+        self.handle = self._get_handle()
+        
+        # 获取设备信息
+        self.device_info = self._get_device_info(device_id)
+    
+    def _setup_dll_functions(self):
+        """设置DLL函数原型"""
+        # 创建设备
+        self._dam3000m.DAM3000M_CreateDevice.argtypes = [wintypes.LONG]
+        self._dam3000m.DAM3000M_CreateDevice.restype = wintypes.HANDLE
+        
+        # 初始化设备
+        self._dam3000m.DAM3000M_InitDevice.argtypes = [
+            wintypes.HANDLE, wintypes.LONG, wintypes.LONG, 
+            wintypes.LONG, wintypes.LONG, wintypes.LONG, wintypes.LONG
+        ]
+        self._dam3000m.DAM3000M_InitDevice.restype = wintypes.BOOL
+        
+        # 释放设备
+        self._dam3000m.DAM3000M_ReleaseDevice.argtypes = [wintypes.HANDLE]
+        self._dam3000m.DAM3000M_ReleaseDevice.restype = wintypes.BOOL
+        
+        # 获取设备信息
+        self._dam3000m.DAM3000M_GetDeviceInfo.argtypes = [
+            wintypes.HANDLE, wintypes.LONG, ctypes.POINTER(DeviceInfo)
+        ]
+        self._dam3000m.DAM3000M_GetDeviceInfo.restype = wintypes.BOOL
+        
+        # 写单个寄存器
+        self._dam3000m.DAM3000M_WriteSingleReg.argtypes = [
+            wintypes.HANDLE, wintypes.LONG, wintypes.LONG, wintypes.ULONG
+        ]
+        self._dam3000m.DAM3000M_WriteSingleReg.restype = wintypes.BOOL
+        
+        # 读输入寄存器 (UInt16)
+        self._dam3000m.DAM3000M_ReadInputRegsUInt16.argtypes = [
+            wintypes.HANDLE, wintypes.LONG, wintypes.INT, 
+            wintypes.INT, ctypes.POINTER(wintypes.USHORT)
+        ]
+        self._dam3000m.DAM3000M_ReadInputRegsUInt16.restype = wintypes.BOOL
+    
+    def _get_handle(self) -> wintypes.HANDLE:
+        """获取设备句柄（支持句柄共享）"""
+        if self.com_id not in self._handles:
+            handle = self._dam3000m.DAM3000M_CreateDevice(self.com_id)
+            if handle in (-1, None, 0):
+                raise RuntimeError(f"创建设备失败: COM{self.com_id}")
+            
+            # 初始化设备: baud_rate, 8位数据位, 无校验, 1位停止位
+            if not self._dam3000m.DAM3000M_InitDevice(handle, self.baud_rate, 8, 0, 0x00, 200, 0):
+                raise RuntimeError(f"初始化设备失败: COM{self.com_id}")
+            
+            self._handles[self.com_id] = handle
+        
+        return self._handles[self.com_id]
+    
+    def _get_device_info(self, device_id: int) -> DeviceInfo:
+        """获取设备信息"""
+        device_info = DeviceInfo()
+        if not self._dam3000m.DAM3000M_GetDeviceInfo(self.handle, device_id, ctypes.byref(device_info)):
+            raise RuntimeError(f"获取设备信息失败: 设备ID {device_id}")
+        return device_info
+    
+    @property
+    def device_name(self) -> str:
+        """获取设备名称"""
+        name = f"DAM-{self.device_info.DeviceType:02X}{chr(self.device_info.TypeSuffix >> 8 & 0xFF)}"
+        return name.rstrip(' ')
+    
+    def write_single_reg(self, reg_addr: int, value: int) -> bool:
+        """写单个寄存器"""
+        return self._dam3000m.DAM3000M_WriteSingleReg(
+            self.handle, self.device_id, reg_addr, value
+        )
+    
+    def read_input_regs_uint16(self, start_addr: int, count: int) -> list:
+        """读输入寄存器 (16位无符号)"""
+        buffer_type = ctypes.c_ushort * count
+        data_buffer = buffer_type()
+        
+        if not self._dam3000m.DAM3000M_ReadInputRegsUInt16(
+            self.handle, self.device_id, start_addr, count, data_buffer
+        ):
+            raise RuntimeError(f"读输入寄存器失败: 起始地址 {start_addr}, 数量 {count}")
+        
+        return list(data_buffer)
+    
+    def close(self):
+        """关闭设备连接"""
+        if self.com_id in self._handles:
+            self._dam3000m.DAM3000M_ReleaseDevice(self._handles[self.com_id])
+            del self._handles[self.com_id]
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False


### PR DESCRIPTION
## 概述

本PR实现了对阿尔泰科技DAM3000M系列控制仪表的支持，解决了 #237 提出的需求。

## 新增功能

### 1. DAM3060V - 4通道模拟输出模块
- 支持4通道独立电压输出控制
- 支持4种输出范围模式：
  - -10V ~ 10V
  - -5V ~ 5V
  - 0V ~ 10V
  - 0V ~ 5V
- 提供标准接口：
  - `set_analog_output(channel, voltage)`: 设置输出电压
  - `set_output_range_mode(channel, range_code)`: 设置输出范围
  - `get_range_mode(channel)`: 获取当前量程范围

### 2. DAM3151 - 32通道模拟输入模块
- 支持32通道同步数据采集
- 支持电压和电流两种测量模式
- 支持12种测量范围：
  - 电压: -10V~10V, -5V~5V, -1V~1V, -500mV~500mV, -150mV~150mV, 0V~10V, 0V~5V, 1V~5V
  - 电流: -20mA~20mA, 0mA~20mA, 4mA~20mA, 0mA~22mA
- 提供标准接口：
  - `measure_all_channels()`: 测量所有通道
  - `measure_channel(channel)`: 测量单个通道
  - `set_measurement_range_mode(channel, range_code)`: 设置测量范围
  - `get_range_mode(channel)`: 获取当前量程范围

### 3. 设备基类 (DAMDeviceBase)
- 封装DLL调用细节
- 支持设备句柄共享（同一串口）
- 提供通用的读写寄存器接口
- 实现上下文管理器模式

## 技术实现

### 目录结构
```
unilabos/devices/altai_dam/
├── __init__.py          # 模块导出
├── dam_base.py          # 设备基类
├── dam3060v.py          # DAM3060V实现
└── dam3151.py           # DAM3151实现
```

### 设计特点
1. **封装良好**: 隐藏DLL调用细节，提供简洁的Python API
2. **类型安全**: 使用类型注解，提高代码可读性
3. **错误处理**: 完善的参数检查和异常处理
4. **资源管理**: 支持上下文管理器，自动释放资源
5. **句柄共享**: 同一串口的设备共享句柄，提高效率

## 使用示例

### DAM3060V - 设置电压输出
```python
from unilabos.devices.altai_dam import DAM3060V

# 创建设备实例 (COM4, 9600 bps, 设备ID=1)
with DAM3060V(com_id=4, baud_rate=3, device_id=1) as device:
    # 设置通道0输出范围为 -5V ~ 5V
    device.set_output_range_mode(0, 8)
    
    # 设置通道0输出 2.5V
    device.set_analog_output(0, 2.5)
```

### DAM3151 - 测量数据采集
```python
from unilabos.devices.altai_dam import DAM3151

# 创建设备实例 (COM4, 9600 bps, 设备ID=5)
with DAM3151(com_id=4, baud_rate=3, device_id=5) as device:
    # 设置通道0为 -20mA ~ 20mA 电流测量
    device.set_measurement_range_mode(0, 10)
    
    # 测量所有通道
    measurements = device.measure_all_channels()
    print(f"通道0电流: {measurements[0]} mA")
```

## 依赖说明

- **系统要求**: Windows系统（DLL限制）
- **DLL文件**: 需要将 `DAM3000M_64.dll` 放置在工作目录或指定路径

## 相关Issue

Fixes #237

## 注意事项

1. 本实现仅支持Windows系统（DLL限制）
2. 需要配合阿尔泰官方DLL使用
3. 建议在实际使用前进行充分测试

## 致谢

参考了 [ART-CONTROL-Python-Interface](https://github.com/newtontech/ART-CONTROL-Python-Interface) 的实现思路。