### PR TITLE
 feat(sim): add managed Isaac bridge and joint control UIfeat: add Isaac managed joint control UI

### DIFF
--- a/tests/sim/backends/test_isaac_bridge.py
+++ b/tests/sim/backends/test_isaac_bridge.py
@@ -25,6 +25,22 @@ class _RpcHandler(BaseHTTPRequestHandler):
             result = {"entity_id": args["entity_id"], "tcp_pose": [1, 2, 3, 0, 0, 0]}
         elif op == "get_joint_states":
             result = {"joint_1": 1.0}
+        elif op == "list_joint_controls":
+            result = [{"name": "arm1_joint"}]
+        elif op == "get_joint_control_state":
+            result = {"status": "ready"}
+        elif op == "plan_joint_targets":
+            result = {"plan_id": "plan_0001", "targets": args["targets"], "options": args["options"]}
+        elif op == "check_joint_plan":
+            result = {"plan_id": args["plan_id"], "safe": True}
+        elif op == "execute_joint_plan":
+            result = {"plan_id": args["plan_id"], "ok": True}
+        elif op == "stop_joint_motion":
+            result = {"ok": True, "code": "stopped"}
+        elif op == "set_collision_check_enabled":
+            result = {"collision_check_enabled": bool(args["enabled"])}
+        elif op == "apply_stable_drive_settings":
+            result = {"ok": True, "code": "stable_drive_applied"}
         elif op == "attach_rigid_body":
             result = "beaker"
         elif op == "render":
@@ -62,12 +78,32 @@ def test_isaac_bridge_forwards_backend_methods_over_http():
         backend.set_command("arm", {"type": "move_j"})
         observation = backend.get_observation("arm")
         joints = backend.get_joint_states("arm")
+        joint_controls = backend.list_joint_controls()
+        joint_state = backend.get_joint_control_state()
+        joint_plan = backend.plan_joint_targets({"arm1_joint": 10.0}, {"max_revolute_step_deg": 5.0})
+        joint_check = backend.check_joint_plan("plan_0001")
+        joint_execute = backend.execute_joint_plan("plan_0001")
+        joint_stop = backend.stop_joint_motion()
+        collision_mode = backend.set_collision_check_enabled(False)
+        stable_drive = backend.apply_stable_drive_settings()
         body_id = backend.attach_rigid_body("beaker", "beaker.usd", {"xyz": [0, 0, 0]})
         backend.apply_wrench("arm", {"force": [1, 0, 0]})
         image = backend.render("/World/Camera", 320, 240)
 
         assert observation["entity_id"] == "arm"
         assert joints == {"joint_1": 1.0}
+        assert joint_controls == [{"name": "arm1_joint"}]
+        assert joint_state == {"status": "ready"}
+        assert joint_plan == {
+            "plan_id": "plan_0001",
+            "targets": {"arm1_joint": 10.0},
+            "options": {"max_revolute_step_deg": 5.0},
+        }
+        assert joint_check == {"plan_id": "plan_0001", "safe": True}
+        assert joint_execute == {"plan_id": "plan_0001", "ok": True}
+        assert joint_stop == {"ok": True, "code": "stopped"}
+        assert collision_mode == {"collision_check_enabled": False}
+        assert stable_drive == {"ok": True, "code": "stable_drive_applied"}
         assert body_id == "beaker"
         assert image == b"png-bytes"
         assert [call["op"] for call in _RpcHandler.calls] == [
@@ -77,6 +113,14 @@ def test_isaac_bridge_forwards_backend_methods_over_http():
             "set_command",
             "get_observation",
             "get_joint_states",
+            "list_joint_controls",
+            "get_joint_control_state",
+            "plan_joint_targets",
+            "check_joint_plan",
+            "execute_joint_plan",
+            "stop_joint_motion",
+            "set_collision_check_enabled",
+            "apply_stable_drive_settings",
             "attach_rigid_body",
             "apply_wrench",
             "render",

--- a/tests/sim/backends/test_isaac_joint_control.py
+++ b/tests/sim/backends/test_isaac_joint_control.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import pytest
+
+from unilabos.sim.backends.isaac.joint_control import (
+    DEFAULT_MVPPKUSHENGKE_JOINTS,
+    DEFAULT_STABLE_DRIVE_SETTINGS,
+    JointControlError,
+    JointControlService,
+    PlanOptions,
+)
+
+
+class FakeJointAdapter:
+    def __init__(self, positions=None, unsafe_waypoint=None, baseline_contacts=None):
+        self.positions = dict(positions or {})
+        self.unsafe_waypoint = unsafe_waypoint
+        self.baseline_contacts = [dict(contact) for contact in (baseline_contacts or [])]
+        self.applied_targets = []
+        self.step_calls = []
+        self.contact_reads = 0
+        self.drive_settings = {}
+        self.captured = None
+        self.restored = None
+
+    def list_joint_specs(self):
+        return DEFAULT_MVPPKUSHENGKE_JOINTS
+
+    def get_joint_positions(self):
+        return dict(self.positions)
+
+    def capture_state(self):
+        self.captured = dict(self.positions)
+        return dict(self.positions)
+
+    def restore_state(self, state):
+        self.restored = dict(state)
+        self.positions = dict(state)
+
+    def set_joint_targets(self, targets):
+        self.applied_targets.append(dict(targets))
+        self.positions.update({str(key): float(value) for key, value in targets.items()})
+
+    def step_simulation(self, steps):
+        self.step_calls.append(int(steps))
+
+    def get_disallowed_contacts(self):
+        self.contact_reads += 1
+        waypoint_index = len(self.applied_targets) - 1
+        contacts = [dict(contact) for contact in self.baseline_contacts]
+        if self.unsafe_waypoint == waypoint_index:
+            contacts.append({"body0": "/World/arm3_Link", "body1": "/World/base_link"})
+        return contacts
+
+    def apply_drive_settings(self, settings):
+        self.drive_settings = {str(name): dict(values) for name, values in settings.items()}
+        return self.drive_settings
+
+
+def test_default_mvppkushengke_joint_specs_have_expected_units_and_limits():
+    specs = {spec.name: spec for spec in DEFAULT_MVPPKUSHENGKE_JOINTS}
+
+    assert specs["arm1_joint"].unit == "deg"
+    assert specs["arm1_joint"].drive_axis == "angular"
+    assert specs["arm1_joint"].lower_limit == pytest.approx(-114.591552734375)
+    assert specs["arm1_joint"].upper_limit == pytest.approx(114.591552734375)
+    assert specs["arm0_joint"].unit == "m"
+    assert specs["arm0_joint"].drive_axis == "linear"
+    assert specs["arm0_joint"].upper_limit == pytest.approx(0.4300000071525574)
+
+
+def test_plan_joint_targets_interpolates_by_largest_joint_step():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0, "arm0_joint": 0.0})
+    service = JointControlService(adapter)
+
+    plan = service.plan_joint_targets(
+        {"arm1_joint": 12.0, "arm0_joint": 0.05},
+        PlanOptions(max_revolute_step_deg=5.0, max_prismatic_step_m=0.02),
+    )
+
+    assert len(plan.waypoints) == 3
+    assert plan.waypoints[0]["arm1_joint"] == pytest.approx(4.0)
+    assert plan.waypoints[0]["arm0_joint"] == pytest.approx(0.0166666667)
+    assert plan.waypoints[-1] == {"arm1_joint": 12.0, "arm0_joint": 0.05}
+    assert service.get_joint_control_state()["last_plan"]["plan_id"] == plan.plan_id
+
+
+def test_plan_joint_targets_has_no_waypoints_for_noop_targets():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0, "arm0_joint": 0.0})
+    service = JointControlService(adapter)
+
+    plan = service.plan_joint_targets({"arm1_joint": 0.0, "arm0_joint": 0.0})
+
+    assert plan.waypoints == []
+
+
+def test_plan_joint_targets_rejects_unknown_or_out_of_limit_targets():
+    service = JointControlService(FakeJointAdapter({"arm1_joint": 0.0}))
+
+    with pytest.raises(JointControlError, match="unknown_joint"):
+        service.plan_joint_targets({"unknown_joint": 1.0})
+
+    with pytest.raises(JointControlError, match="joint_limit_exceeded"):
+        service.plan_joint_targets({"arm1_joint": 200.0})
+
+
+def test_execute_requires_checked_safe_plan():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0})
+    service = JointControlService(adapter)
+    plan = service.plan_joint_targets({"arm1_joint": 5.0})
+
+    with pytest.raises(JointControlError, match="plan_not_checked"):
+        service.execute_joint_plan(plan.plan_id)
+
+    check = service.check_joint_plan(plan.plan_id)
+    result = service.execute_joint_plan(plan.plan_id)
+
+    assert check.safe is True
+    assert result.ok is True
+    assert adapter.applied_targets[-1] == {"arm1_joint": 5.0}
+
+
+def test_collision_check_rejects_unsafe_plan_and_restores_state():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0}, unsafe_waypoint=1)
+    service = JointControlService(adapter)
+    plan = service.plan_joint_targets({"arm1_joint": 12.0}, PlanOptions(max_revolute_step_deg=5.0))
+
+    check = service.check_joint_plan(plan.plan_id)
+
+    assert check.safe is False
+    assert check.code == "collision_detected"
+    assert check.waypoint_index == 1
+    assert check.contacts == [{"body0": "/World/arm3_Link", "body1": "/World/base_link"}]
+    assert adapter.restored == {"arm1_joint": 0.0}
+    with pytest.raises(JointControlError, match="plan_not_safe"):
+        service.execute_joint_plan(plan.plan_id)
+
+
+def test_collision_check_ignores_contacts_present_before_plan():
+    baseline_contact = {"body0": "/World/base_link", "body1": "/World/table"}
+    adapter = FakeJointAdapter({"arm1_joint": 0.0}, baseline_contacts=[baseline_contact])
+    service = JointControlService(adapter)
+    plan = service.plan_joint_targets({"arm1_joint": 8.0}, PlanOptions(max_revolute_step_deg=4.0))
+
+    check = service.check_joint_plan(plan.plan_id)
+
+    assert check.safe is True
+    assert check.code == "safe"
+    assert check.contacts == []
+    assert adapter.restored == {"arm1_joint": 0.0}
+
+
+def test_collision_check_reports_only_new_contacts_after_baseline():
+    baseline_contact = {"body0": "/World/base_link", "body1": "/World/table"}
+    adapter = FakeJointAdapter(
+        {"arm1_joint": 0.0},
+        unsafe_waypoint=1,
+        baseline_contacts=[baseline_contact],
+    )
+    service = JointControlService(adapter)
+    plan = service.plan_joint_targets({"arm1_joint": 12.0}, PlanOptions(max_revolute_step_deg=5.0))
+
+    check = service.check_joint_plan(plan.plan_id)
+
+    assert check.safe is False
+    assert check.code == "collision_detected"
+    assert check.waypoint_index == 1
+    assert check.contacts == [{"body0": "/World/arm3_Link", "body1": "/World/base_link"}]
+
+
+def test_collision_check_can_be_disabled_and_reports_mode_in_state():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0}, unsafe_waypoint=0)
+    service = JointControlService(adapter)
+    service.set_collision_check_enabled(False)
+    plan = service.plan_joint_targets({"arm1_joint": 5.0}, PlanOptions(max_revolute_step_deg=5.0))
+
+    check = service.check_joint_plan(plan.plan_id)
+
+    assert service.get_joint_control_state()["collision_check_enabled"] is False
+    assert check.safe is True
+    assert check.code == "collision_check_disabled"
+    assert check.message == "Collision check is disabled"
+    assert adapter.contact_reads == 0
+    assert adapter.applied_targets == []
+
+
+def test_apply_stable_drive_settings_updates_adapter_and_state():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0})
+    service = JointControlService(adapter)
+
+    result = service.apply_stable_drive_settings()
+
+    assert result["ok"] is True
+    assert result["code"] == "stable_drive_applied"
+    assert result["settings"]["arm1_joint"] == DEFAULT_STABLE_DRIVE_SETTINGS["arm1_joint"]
+    assert adapter.drive_settings["arm0_joint"] == DEFAULT_STABLE_DRIVE_SETTINGS["arm0_joint"]
+    state = service.get_joint_control_state()
+    assert state["drive_tuning"]["mode"] == "stable"
+    assert state["drive_tuning"]["settings"]["arm3_joint"] == DEFAULT_STABLE_DRIVE_SETTINGS["arm3_joint"]
+
+
+def test_execute_allows_unchecked_plan_when_collision_check_disabled():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0}, unsafe_waypoint=0)
+    service = JointControlService(adapter)
+    service.set_collision_check_enabled(False)
+    plan = service.plan_joint_targets({"arm1_joint": 5.0}, PlanOptions(max_revolute_step_deg=5.0))
+
+    result = service.execute_joint_plan(plan.plan_id)
+
+    assert result.ok is True
+    assert result.code == "executed"
+    assert adapter.contact_reads == 0
+    assert adapter.applied_targets[-1] == {"arm1_joint": 5.0}
+
+
+def test_stop_joint_motion_prevents_running_execution():
+    adapter = FakeJointAdapter({"arm1_joint": 0.0})
+    service = JointControlService(adapter)
+
+    service.stop_joint_motion()
+
+    assert service.get_joint_control_state()["status"] == "stopped"

--- a/tests/sim/backends/test_isaac_managed.py
+++ b/tests/sim/backends/test_isaac_managed.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import pytest
+
+from unilabos.sim.backends.isaac import managed
+from unilabos.sim.backends.isaac.managed import (
+    IsaacWorkerHealthError,
+    ManagedIsaacWorker,
+    ManagedIsaacWorkerConfig,
+)
+
+
+def test_config_derives_endpoint_from_host_and_port():
+    config = ManagedIsaacWorkerConfig(enabled=True, host="127.0.0.1", port=8092)
+
+    assert config.endpoint == "http://127.0.0.1:8092"
+
+
+def test_plain_python_worker_command_includes_scene_and_camera():
+    config = ManagedIsaacWorkerConfig(
+        enabled=True,
+        host="127.0.0.1",
+        port=8092,
+        scene="/tmp/lab.usd",
+        camera="/World/DemoCamera",
+        headless=True,
+        python_executable="/opt/unilab/bin/python",
+        repo_root=Path("/repo"),
+        rpc_timeout_s=600.0,
+    )
+
+    command = ManagedIsaacWorker(config).build_command()
+
+    assert command == [
+        "/opt/unilab/bin/python",
+        "-m",
+        "unilabos.sim.backends.isaac.worker",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8092",
+        "--headless",
+        "--scene",
+        "/tmp/lab.usd",
+        "--camera",
+        "/World/DemoCamera",
+        "--warmup-steps",
+        "2",
+        "--rpc-timeout-s",
+        "600.0",
+    ]
+
+
+def test_conda_worker_command_matches_4090_matterix_shape():
+    config = ManagedIsaacWorkerConfig(
+        enabled=True,
+        host="127.0.0.1",
+        port=8092,
+        scene="/home/ubuntu/labsim/LabUtopia_repro/assets/chemistry_lab/lab_001/lab_001.usd",
+        conda_env="matterix",
+        conda_executable="/home/ubuntu/miniforge3/bin/conda",
+        python_executable="python",
+        repo_root=Path("/tmp/Uni-Lab-OS-phase2-c3c5"),
+    )
+
+    command = ManagedIsaacWorker(config).build_command()
+
+    assert command[:6] == [
+        "/home/ubuntu/miniforge3/bin/conda",
+        "run",
+        "--no-capture-output",
+        "-n",
+        "matterix",
+        "python",
+    ]
+    assert command[6:8] == ["-m", "unilabos.sim.backends.isaac.worker"]
+    assert "--scene" in command
+
+
+def test_worker_command_includes_joint_control_ui_when_enabled():
+    config = ManagedIsaacWorkerConfig(
+        enabled=True,
+        joint_control_ui=True,
+        python_executable="/opt/unilab/bin/python",
+        repo_root=Path("/repo"),
+    )
+
+    command = ManagedIsaacWorker(config).build_command()
+
+    assert "--joint-control-ui" in command
+
+
+def test_worker_environment_prepends_repo_root_to_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/existing")
+    config = ManagedIsaacWorkerConfig(enabled=True, repo_root=Path("/repo"))
+
+    env = ManagedIsaacWorker(config).build_env()
+
+    assert env["PYTHONPATH"] == "/repo:/existing"
+
+
+def test_wait_until_healthy_retries_until_health_ok():
+    class TestWorker(ManagedIsaacWorker):
+        def __init__(self, config):
+            super().__init__(config)
+            self.calls = 0
+
+        def _read_health(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise OSError("not ready")
+            return {"ok": True}
+
+    worker = TestWorker(ManagedIsaacWorkerConfig(enabled=True))
+    worker.process = _FakeProcess()
+
+    worker.wait_until_healthy(timeout_s=1.0, interval_s=0.0)
+
+    assert worker.calls == 2
+
+
+def test_wait_until_healthy_raises_when_process_exits():
+    worker = ManagedIsaacWorker(ManagedIsaacWorkerConfig(enabled=True))
+    worker.process = _FakeProcess(returncode=7)
+
+    with pytest.raises(IsaacWorkerHealthError, match="exited before becoming healthy"):
+        worker.wait_until_healthy(timeout_s=1.0, interval_s=0.0)
+
+
+def test_stop_terminates_worker_process_group(monkeypatch):
+    calls = []
+    process = _FakeProcess()
+    worker = ManagedIsaacWorker(ManagedIsaacWorkerConfig(enabled=True))
+    worker.process = process
+    monkeypatch.setattr(managed.os, "killpg", lambda pid, signal_number: calls.append((pid, signal_number)))
+
+    worker.stop()
+
+    assert calls == [(process.pid, managed.signal.SIGTERM)]
+    assert process.waited is True
+
+
+class _FakeProcess:
+    def __init__(self, returncode=None):
+        self.pid = 1234
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        self.waited = True
+        return self.returncode

--- a/tests/sim/backends/test_isaac_worker_cli.py
+++ b/tests/sim/backends/test_isaac_worker_cli.py
@@ -29,6 +29,13 @@ def test_worker_parse_args_defaults():
     assert args.scene is None
     assert args.camera == "/World/Camera"
     assert args.rpc_timeout_s == 600.0
+    assert args.joint_control_ui is False
+
+
+def test_worker_parse_args_accepts_joint_control_ui():
+    args = worker.parse_args(["--joint-control-ui"])
+
+    assert args.joint_control_ui is True
 
 
 def test_worker_state_dispatches_to_controller():

--- a/tests/sim/backends/test_isaac_worker_protocol.py
+++ b/tests/sim/backends/test_isaac_worker_protocol.py
@@ -1,7 +1,10 @@
 import json
+from types import MethodType
 
 import pytest
 
+from unilabos.sim.backends.isaac import worker
+from unilabos.sim.backends.isaac.worker import IsaacWorkerState
 from unilabos.sim.backends.isaac.protocol import decode_request, encode_error, encode_response
 
 
@@ -32,3 +35,129 @@ def test_encode_error_matches_client_decode_shape():
     body = encode_error("bad scene")
 
     assert json.loads(body.decode("utf-8")) == {"ok": False, "error": "bad scene"}
+
+
+class FakeJointController:
+    def list_joint_controls(self):
+        return [{"name": "arm1_joint"}]
+
+    def get_joint_control_state(self):
+        return {"status": "ready"}
+
+    def plan_joint_targets(self, targets, options=None):
+        return {"plan_id": "plan_0001", "targets": targets, "options": options or {}}
+
+    def check_joint_plan(self, plan_id):
+        return {"plan_id": plan_id, "safe": True}
+
+    def execute_joint_plan(self, plan_id):
+        return {"plan_id": plan_id, "ok": True}
+
+    def stop_joint_motion(self):
+        return {"ok": True, "code": "stopped"}
+
+    def set_collision_check_enabled(self, enabled):
+        return {"collision_check_enabled": bool(enabled)}
+
+    def apply_stable_drive_settings(self):
+        return {"ok": True, "code": "stable_drive_applied"}
+
+
+class FakeJointControlService:
+    def __init__(self):
+        self.enabled = True
+        self.drive_applied = False
+
+    def get_joint_control_state(self):
+        return {"collision_check_enabled": self.enabled}
+
+    def set_collision_check_enabled(self, enabled):
+        self.enabled = bool(enabled)
+        return {"collision_check_enabled": self.enabled}
+
+    def apply_stable_drive_settings(self):
+        self.drive_applied = True
+        return {"ok": True, "code": "stable_drive_applied"}
+
+
+class FakeApp:
+    def __init__(self):
+        self.updates = 0
+
+    def update(self):
+        self.updates += 1
+
+
+class FakeStringModel:
+    def __init__(self, value=""):
+        self.value = value
+
+    def set_value(self, value):
+        self.value = str(value)
+
+
+def test_worker_dispatches_joint_control_operations():
+    state = IsaacWorkerState(FakeJointController())
+
+    assert state.dispatch("list_joint_controls", {}) == [{"name": "arm1_joint"}]
+    assert state.dispatch("get_joint_control_state", {}) == {"status": "ready"}
+    assert state.dispatch("plan_joint_targets", {"targets": {"arm1_joint": 10.0}}) == {
+        "plan_id": "plan_0001",
+        "targets": {"arm1_joint": 10.0},
+        "options": {},
+    }
+    assert state.dispatch("check_joint_plan", {"plan_id": "plan_0001"}) == {
+        "plan_id": "plan_0001",
+        "safe": True,
+    }
+    assert state.dispatch("execute_joint_plan", {"plan_id": "plan_0001"}) == {
+        "plan_id": "plan_0001",
+        "ok": True,
+    }
+    assert state.dispatch("stop_joint_motion", {}) == {"ok": True, "code": "stopped"}
+    assert state.dispatch("set_collision_check_enabled", {"enabled": False}) == {"collision_check_enabled": False}
+    assert state.dispatch("apply_stable_drive_settings", {}) == {"ok": True, "code": "stable_drive_applied"}
+
+
+def test_isaac_controller_runs_queued_ui_actions_before_idle_update():
+    controller = object.__new__(worker.IsaacController)
+    controller.app = FakeApp()
+    controller._joint_control_status_model = None
+    controller._init_ui_action_queue()
+    events = []
+
+    controller._enqueue_ui_action("Check", lambda: events.append(("action", controller.app.updates)))
+
+    assert events == []
+
+    controller.idle()
+
+    assert events == [("action", 0)]
+    assert controller.app.updates == 1
+
+
+def test_isaac_controller_toggles_collision_check_from_ui_action():
+    controller = object.__new__(worker.IsaacController)
+    controller._joint_control_status_model = None
+    controller._collision_mode_model = FakeStringModel()
+    service = FakeJointControlService()
+    controller._get_joint_control_service = MethodType(lambda _self: service, controller)
+
+    controller._ui_toggle_collision_check_now()
+
+    assert service.enabled is False
+    assert "OFF" in controller._collision_mode_model.value
+    assert "bypasses" in controller._collision_mode_model.value
+
+
+def test_isaac_controller_applies_stable_drive_from_ui_action():
+    controller = object.__new__(worker.IsaacController)
+    controller._joint_control_status_model = FakeStringModel()
+    controller._collision_mode_model = FakeStringModel()
+    service = FakeJointControlService()
+    controller._get_joint_control_service = MethodType(lambda _self: service, controller)
+
+    controller._ui_apply_stable_drive_now()
+
+    assert service.drive_applied is True
+    assert "Stable drive applied" in controller._joint_control_status_model.value

--- a/tests/sim/test_backend_physics_configuration.py
+++ b/tests/sim/test_backend_physics_configuration.py
@@ -2,6 +2,10 @@ from unilabos.app import backend as backend_mod
 from unilabos.sim.backends.fake_physics import FakePhysicsBackend
 
 
+class _DummyPhysics:
+    name = "dummy"
+
+
 def test_initialize_runtime_for_backend_builds_fake_physics():
     services = backend_mod._initialize_runtime_for_backend(
         backend="ros",
@@ -37,3 +41,111 @@ def test_initialize_runtime_for_non_ros_keeps_query_api_off():
 
     assert services.context.physics is None
     assert services.context.query_api_enabled is False
+
+
+def test_initialize_runtime_for_backend_starts_managed_isaac(monkeypatch):
+    started_configs = []
+    build_calls = []
+    dummy_physics = _DummyPhysics()
+
+    class FakeManagedWorker:
+        def __init__(self, config):
+            self.config = config
+            self.endpoint = config.endpoint
+            self.stopped = False
+
+        def start(self):
+            started_configs.append(self.config)
+
+        def stop(self):
+            self.stopped = True
+
+    def fake_build_physics_backend(name, endpoint=None, scene=None, timeout=120.0):
+        build_calls.append({"name": name, "endpoint": endpoint, "scene": scene, "timeout": timeout})
+        return dummy_physics
+
+    monkeypatch.setattr(backend_mod, "ManagedIsaacWorker", FakeManagedWorker)
+    monkeypatch.setattr(backend_mod, "build_physics_backend", fake_build_physics_backend)
+    monkeypatch.setattr(backend_mod.atexit, "register", lambda _callback: None)
+    monkeypatch.setattr(backend_mod.signal, "getsignal", lambda _signum: backend_mod.signal.SIG_DFL)
+    monkeypatch.setattr(backend_mod.signal, "signal", lambda _signum, _handler: None)
+    monkeypatch.setattr(backend_mod, "_managed_isaac_shutdown_registered", False)
+
+    services = backend_mod._initialize_runtime_for_backend(
+        backend="ros",
+        kwargs={
+            "mode": "sim",
+            "physics": "isaac",
+            "physics_endpoint": None,
+            "physics_scene": "/home/ubuntu/labsim/LabUtopia_repro/assets/chemistry_lab/lab_001/lab_001.usd",
+            "physics_timeout": 300.0,
+            "isaac_managed": True,
+            "isaac_host": "127.0.0.1",
+            "isaac_port": 8092,
+            "isaac_conda_env": "matterix",
+            "isaac_conda_executable": "/home/ubuntu/miniforge3/bin/conda",
+            "isaac_python": "python",
+            "isaac_log_path": "/tmp/isaac_worker.log",
+            "isaac_start_timeout": 300.0,
+            "isaac_headless": True,
+            "isaac_camera": "/World/Camera",
+            "isaac_rpc_timeout_s": 600.0,
+            "isaac_joint_control_ui": True,
+        },
+    )
+
+    assert len(started_configs) == 1
+    assert started_configs[0].conda_env == "matterix"
+    assert started_configs[0].port == 8092
+    assert started_configs[0].joint_control_ui is True
+    assert build_calls == [
+        {
+            "name": "isaac",
+            "endpoint": "http://127.0.0.1:8092",
+            "scene": "/home/ubuntu/labsim/LabUtopia_repro/assets/chemistry_lab/lab_001/lab_001.usd",
+            "timeout": 300.0,
+        }
+    ]
+    assert services.context.physics is dummy_physics
+    assert services.context.physics_endpoint == "http://127.0.0.1:8092"
+
+
+def test_managed_isaac_requires_isaac_physics():
+    try:
+        backend_mod._initialize_runtime_for_backend(
+            backend="ros",
+            kwargs={"mode": "sim", "physics": "fake", "isaac_managed": True},
+        )
+    except ValueError as exc:
+        assert "--isaac_managed requires --physics isaac" in str(exc)
+    else:
+        raise AssertionError("managed Isaac must reject non-Isaac physics")
+
+
+def test_managed_isaac_signal_handler_stops_worker_and_chains_previous(monkeypatch):
+    events = []
+    registered = {}
+
+    class FakeWorker:
+        def stop(self):
+            events.append("stop")
+
+    def previous_handler(signum, frame):
+        events.append(("previous", signum, frame))
+
+    monkeypatch.setattr(backend_mod.atexit, "register", lambda callback: events.append(("atexit", callback)))
+    monkeypatch.setattr(backend_mod.signal, "getsignal", lambda _signum: previous_handler)
+    monkeypatch.setattr(
+        backend_mod.signal,
+        "signal",
+        lambda signum, handler: registered.setdefault(signum, handler),
+    )
+    monkeypatch.setattr(backend_mod, "_managed_isaac_shutdown_registered", False)
+    monkeypatch.setattr(backend_mod, "_managed_isaac_worker", FakeWorker())
+
+    backend_mod._register_managed_isaac_shutdown()
+    registered[backend_mod.signal.SIGTERM](backend_mod.signal.SIGTERM, None)
+
+    assert events[0][0] == "atexit"
+    assert "stop" in events
+    assert ("previous", backend_mod.signal.SIGTERM, None) in events

--- a/tests/sim/test_cli_runtime.py
+++ b/tests/sim/test_cli_runtime.py
@@ -27,6 +27,18 @@ def test_cli_physics_defaults_are_backward_compatible():
     assert args.physics_endpoint is None
     assert args.physics_scene is None
     assert args.physics_timeout == 120.0
+    assert args.isaac_managed is False
+    assert args.isaac_host == "127.0.0.1"
+    assert args.isaac_port == 8091
+    assert args.isaac_conda_env is None
+    assert args.isaac_conda_executable == "conda"
+    assert args.isaac_python == "python"
+    assert args.isaac_log_path is None
+    assert args.isaac_start_timeout == 120.0
+    assert args.isaac_headless is True
+    assert args.isaac_camera == "/World/Camera"
+    assert args.isaac_rpc_timeout_s == 600.0
+    assert args.isaac_joint_control_ui is False
 
 
 def test_cli_accepts_isaac_physics_options():
@@ -49,6 +61,51 @@ def test_cli_accepts_isaac_physics_options():
     assert args.physics_endpoint == "http://127.0.0.1:8091"
     assert args.physics_scene == "/tmp/lab.usd"
     assert args.physics_timeout == 180.0
+
+
+def test_cli_accepts_managed_isaac_worker_options():
+    args = build_argparser().parse_args(
+        [
+            "--mode",
+            "sim",
+            "--physics",
+            "isaac",
+            "--isaac_managed",
+            "--isaac_host",
+            "0.0.0.0",
+            "--isaac_port",
+            "8092",
+            "--isaac_conda_env",
+            "matterix",
+            "--isaac_conda_executable",
+            "/home/ubuntu/miniforge3/bin/conda",
+            "--isaac_python",
+            "python",
+            "--isaac_log_path",
+            "/tmp/isaac_worker.log",
+            "--isaac_start_timeout",
+            "300",
+            "--no_isaac_headless",
+            "--isaac_camera",
+            "/World/DemoCamera",
+            "--isaac_rpc_timeout_s",
+            "900",
+            "--isaac_joint_control_ui",
+        ]
+    )
+
+    assert args.isaac_managed is True
+    assert args.isaac_host == "0.0.0.0"
+    assert args.isaac_port == 8092
+    assert args.isaac_conda_env == "matterix"
+    assert args.isaac_conda_executable == "/home/ubuntu/miniforge3/bin/conda"
+    assert args.isaac_python == "python"
+    assert args.isaac_log_path == "/tmp/isaac_worker.log"
+    assert args.isaac_start_timeout == 300.0
+    assert args.isaac_headless is False
+    assert args.isaac_camera == "/World/DemoCamera"
+    assert args.isaac_rpc_timeout_s == 900.0
+    assert args.isaac_joint_control_ui is True
 
 
 def test_local_graph_fastapi_can_start_without_cloud_auth():

--- a/unilabos/app/backend.py
+++ b/unilabos/app/backend.py
@@ -1,17 +1,87 @@
 from __future__ import annotations
 
+import atexit
+import signal
 import threading
+from pathlib import Path
 
 from unilabos.resources.resource_tracker import ResourceTreeSet
 from unilabos.sim.backends.factory import build_physics_backend
+from unilabos.sim.backends.isaac.managed import ManagedIsaacWorker, ManagedIsaacWorkerConfig
 from unilabos.sim.runtime import RuntimeServices, configure_runtime
 from unilabos.utils import logger
 
 
 _runtime_services: RuntimeServices | None = None
+_managed_isaac_worker: ManagedIsaacWorker | None = None
+_managed_isaac_shutdown_registered = False
+
+
+def _stop_managed_isaac_worker() -> None:
+    global _managed_isaac_worker
+    if _managed_isaac_worker is not None:
+        _managed_isaac_worker.stop()
+        _managed_isaac_worker = None
+
+
+def _register_managed_isaac_shutdown() -> None:
+    global _managed_isaac_shutdown_registered
+    if _managed_isaac_shutdown_registered:
+        return
+    atexit.register(_stop_managed_isaac_worker)
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handler = signal.getsignal(signum)
+
+        def _handler(signum, frame, previous_handler=previous_handler):
+            _stop_managed_isaac_worker()
+            if callable(previous_handler):
+                previous_handler(signum, frame)
+                return
+            if previous_handler == signal.SIG_IGN:
+                return
+            raise SystemExit(128 + signum)
+
+        signal.signal(signum, _handler)
+    _managed_isaac_shutdown_registered = True
+
+
+def _start_managed_isaac_if_requested(kwargs: dict) -> ManagedIsaacWorker | None:
+    global _managed_isaac_worker
+    if not kwargs.get("isaac_managed", False):
+        return None
+    if kwargs.get("physics", "none") != "isaac":
+        raise ValueError("--isaac_managed requires --physics isaac")
+    if _managed_isaac_worker is not None:
+        _stop_managed_isaac_worker()
+
+    config = ManagedIsaacWorkerConfig(
+        enabled=True,
+        host=kwargs.get("isaac_host", "127.0.0.1"),
+        port=int(kwargs.get("isaac_port", 8091)),
+        scene=kwargs.get("physics_scene"),
+        camera=kwargs.get("isaac_camera", "/World/Camera"),
+        headless=bool(kwargs.get("isaac_headless", True)),
+        joint_control_ui=bool(kwargs.get("isaac_joint_control_ui", False)),
+        rpc_timeout_s=float(kwargs.get("isaac_rpc_timeout_s", 600.0)),
+        start_timeout_s=float(kwargs.get("isaac_start_timeout", 120.0)),
+        conda_env=kwargs.get("isaac_conda_env"),
+        conda_executable=kwargs.get("isaac_conda_executable", "conda"),
+        python_executable=kwargs.get("isaac_python", "python"),
+        log_path=kwargs.get("isaac_log_path"),
+        repo_root=Path.cwd(),
+    )
+    worker = ManagedIsaacWorker(config)
+    worker.start()
+    _managed_isaac_worker = worker
+    _register_managed_isaac_shutdown()
+    if not kwargs.get("physics_endpoint"):
+        kwargs["physics_endpoint"] = worker.endpoint
+    logger.info(f"Managed Isaac worker started at {worker.endpoint}")
+    return worker
 
 
 def _initialize_runtime_for_backend(backend: str, kwargs: dict) -> RuntimeServices:
+    managed_worker = _start_managed_isaac_if_requested(kwargs)
     mode = kwargs.get("mode", "real")
     sim_rate = kwargs.get("sim_rate", 1.0)
     sim_paused = kwargs.get("sim_paused", False)
@@ -19,12 +89,17 @@ def _initialize_runtime_for_backend(backend: str, kwargs: dict) -> RuntimeServic
     physics_endpoint = kwargs.get("physics_endpoint")
     physics_scene = kwargs.get("physics_scene")
     physics_timeout = float(kwargs.get("physics_timeout", 120.0))
-    physics = build_physics_backend(
-        physics_name,
-        endpoint=physics_endpoint,
-        scene=physics_scene,
-        timeout=physics_timeout,
-    )
+    try:
+        physics = build_physics_backend(
+            physics_name,
+            endpoint=physics_endpoint,
+            scene=physics_scene,
+            timeout=physics_timeout,
+        )
+    except Exception:
+        if managed_worker is not None:
+            _stop_managed_isaac_worker()
+        raise
     start_sim_services = backend == "ros" and not kwargs.get("disable_sim_services", False)
     services = configure_runtime(
         mode=mode,

--- a/unilabos/app/main.py
+++ b/unilabos/app/main.py
@@ -345,6 +345,87 @@ def build_argparser():
         help="Physics backend RPC timeout in seconds.",
     )
     parser.add_argument(
+        "--isaac_managed",
+        action="store_true",
+        default=False,
+        help="Start and own an Isaac worker process before connecting --physics isaac.",
+    )
+    parser.add_argument(
+        "--isaac_host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for the managed Isaac worker HTTP server.",
+    )
+    parser.add_argument(
+        "--isaac_port",
+        type=int,
+        default=8091,
+        help="Port for the managed Isaac worker HTTP server.",
+    )
+    parser.add_argument(
+        "--isaac_conda_env",
+        type=str,
+        default=None,
+        help="Optional conda environment used to launch the managed Isaac worker.",
+    )
+    parser.add_argument(
+        "--isaac_conda_executable",
+        type=str,
+        default="conda",
+        help="Conda executable used when --isaac_conda_env is set.",
+    )
+    parser.add_argument(
+        "--isaac_python",
+        type=str,
+        default="python",
+        help="Python executable used to launch the managed Isaac worker.",
+    )
+    parser.add_argument(
+        "--isaac_log_path",
+        type=str,
+        default=None,
+        help="Optional log path for managed Isaac worker stdout/stderr.",
+    )
+    parser.add_argument(
+        "--isaac_start_timeout",
+        type=float,
+        default=120.0,
+        help="Seconds to wait for the managed Isaac worker /health endpoint.",
+    )
+    parser.add_argument(
+        "--isaac_headless",
+        "--isaac-headless",
+        dest="isaac_headless",
+        action="store_true",
+        default=True,
+        help="Run the managed Isaac worker in headless mode.",
+    )
+    parser.add_argument(
+        "--no_isaac_headless",
+        "--no-isaac-headless",
+        dest="isaac_headless",
+        action="store_false",
+        help="Run the managed Isaac worker with GUI mode enabled.",
+    )
+    parser.add_argument(
+        "--isaac_camera",
+        type=str,
+        default="/World/Camera",
+        help="Camera prim path passed to the managed Isaac worker.",
+    )
+    parser.add_argument(
+        "--isaac_rpc_timeout_s",
+        type=float,
+        default=600.0,
+        help="Worker-side RPC timeout for managed Isaac dispatch.",
+    )
+    parser.add_argument(
+        "--isaac_joint_control_ui",
+        action="store_true",
+        default=False,
+        help="Show the managed Isaac worker joint control panel inside Isaac Sim.",
+    )
+    parser.add_argument(
         "--disable_query_api",
         action="store_true",
         default=False,

--- a/unilabos/sim/backends/isaac/joint_control.py
+++ b/unilabos/sim/backends/isaac/joint_control.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from itertools import count
+from typing import Any, Protocol
+
+
+class JointControlError(RuntimeError):
+    def __init__(self, code: str, message: str, details: dict[str, Any] | None = None) -> None:
+        self.code = str(code)
+        self.message = str(message)
+        self.details = dict(details or {})
+        super().__init__(f"{self.code}: {self.message}")
+
+
+@dataclass(frozen=True)
+class JointSpec:
+    name: str
+    path: str
+    joint_type: str
+    drive_axis: str
+    unit: str
+    lower_limit: float
+    upper_limit: float
+    body0: str | None = None
+    body1: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PlanOptions:
+    max_revolute_step_deg: float = 5.0
+    max_prismatic_step_m: float = 0.02
+    sim_steps_per_waypoint: int = 4
+    max_waypoints: int = 240
+
+
+DEFAULT_STABLE_DRIVE_SETTINGS: dict[str, dict[str, float]] = {
+    "arm0_joint": {"stiffness": 180.0, "damping": 50.0, "max_force": 800.0},
+    "arm1_joint": {"stiffness": 120.0, "damping": 18.0, "max_force": 1200.0},
+    "arm2_joint": {"stiffness": 90.0, "damping": 14.0, "max_force": 900.0},
+    "arm3_joint": {"stiffness": 45.0, "damping": 8.0, "max_force": 500.0},
+    "left_joint": {"stiffness": 20.0, "damping": 4.0, "max_force": 100.0},
+    "right_joint": {"stiffness": 20.0, "damping": 4.0, "max_force": 100.0},
+    "gate_joint": {"stiffness": 80.0, "damping": 12.0, "max_force": 600.0},
+}
+
+
+@dataclass
+class TrajectoryPlan:
+    plan_id: str
+    start: dict[str, float]
+    targets: dict[str, float]
+    waypoints: list[dict[str, float]]
+    options: PlanOptions = field(default_factory=PlanOptions)
+    checked: bool = False
+    safe: bool | None = None
+    code: str = "unchecked"
+    message: str = "Trajectory has not been checked"
+    contacts: list[dict[str, Any]] = field(default_factory=list)
+    waypoint_index: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["options"] = asdict(self.options)
+        return data
+
+
+@dataclass
+class CollisionCheckResult:
+    plan_id: str
+    safe: bool
+    code: str
+    message: str
+    waypoint_index: int | None = None
+    contacts: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ExecutionResult:
+    plan_id: str | None
+    ok: bool
+    code: str
+    message: str
+    waypoints_executed: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class JointControlAdapter(Protocol):
+    def list_joint_specs(self) -> list[JointSpec]:
+        ...
+
+    def get_joint_positions(self) -> dict[str, float]:
+        ...
+
+    def set_joint_targets(self, targets: dict[str, float]) -> None:
+        ...
+
+    def step_simulation(self, steps: int) -> None:
+        ...
+
+    def get_disallowed_contacts(self) -> list[dict[str, Any]]:
+        ...
+
+    def capture_state(self) -> Any:
+        ...
+
+    def restore_state(self, state: Any) -> None:
+        ...
+
+    def apply_drive_settings(self, settings: dict[str, dict[str, float]]) -> dict[str, dict[str, float]]:
+        ...
+
+
+DEFAULT_MVPPKUSHENGKE_JOINTS: list[JointSpec] = [
+    JointSpec(
+        name="arm0_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/arm0_joint",
+        joint_type="prismatic",
+        drive_axis="linear",
+        unit="m",
+        lower_limit=0.0,
+        upper_limit=0.4300000071525574,
+        body0="/World/HOR_Horizon_V2_1_2508_13/arm_Link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/arm0_Link",
+    ),
+    JointSpec(
+        name="arm1_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/arm1_joint",
+        joint_type="revolute",
+        drive_axis="angular",
+        unit="deg",
+        lower_limit=-114.591552734375,
+        upper_limit=114.591552734375,
+        body0="/World/HOR_Horizon_V2_1_2508_13/arm0_Link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/arm1_Link",
+    ),
+    JointSpec(
+        name="arm2_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/arm2_joint",
+        joint_type="revolute",
+        drive_axis="angular",
+        unit="deg",
+        lower_limit=-114.591552734375,
+        upper_limit=114.591552734375,
+        body0="/World/HOR_Horizon_V2_1_2508_13/arm1_Link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/arm2_Link",
+    ),
+    JointSpec(
+        name="arm3_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/arm3_joint",
+        joint_type="revolute",
+        drive_axis="angular",
+        unit="deg",
+        lower_limit=-114.591552734375,
+        upper_limit=114.591552734375,
+        body0="/World/HOR_Horizon_V2_1_2508_13/arm2_Link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/arm3_Link",
+    ),
+    JointSpec(
+        name="left_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/left_joint",
+        joint_type="prismatic",
+        drive_axis="linear",
+        unit="m",
+        lower_limit=-0.02500000037252903,
+        upper_limit=0.0,
+        body0="/World/HOR_Horizon_V2_1_2508_13/arm3_Link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/left_Link",
+    ),
+    JointSpec(
+        name="right_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/right_joint",
+        joint_type="prismatic",
+        drive_axis="linear",
+        unit="m",
+        lower_limit=0.0,
+        upper_limit=0.02500000037252903,
+        body0="/World/HOR_Horizon_V2_1_2508_13/arm3_Link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/right_Link",
+    ),
+    JointSpec(
+        name="gate_joint",
+        path="/World/HOR_Horizon_V2_1_2508_13/joints/gate_joint",
+        joint_type="revolute",
+        drive_axis="angular",
+        unit="deg",
+        lower_limit=0.0,
+        upper_limit=89.9543685913086,
+        body0="/World/HOR_Horizon_V2_1_2508_13/base_link",
+        body1="/World/HOR_Horizon_V2_1_2508_13/gate_Link",
+    ),
+]
+
+
+class JointControlService:
+    def __init__(self, adapter: JointControlAdapter) -> None:
+        self.adapter = adapter
+        self._plan_ids = count(1)
+        self._plans: dict[str, TrajectoryPlan] = {}
+        self._status = "ready"
+        self._last_result: dict[str, Any] | None = None
+        self._stop_requested = False
+        self._collision_check_enabled = True
+        self._drive_tuning: dict[str, Any] = {"mode": "asset", "settings": {}}
+
+    def list_joints(self) -> list[JointSpec]:
+        return list(self.adapter.list_joint_specs())
+
+    def get_joint_control_state(self) -> dict[str, Any]:
+        positions = self.adapter.get_joint_positions()
+        last_plan = None
+        if self._plans:
+            last_plan = next(reversed(self._plans.values())).to_dict()
+        return {
+            "status": self._status,
+            "collision_check_enabled": self._collision_check_enabled,
+            "drive_tuning": dict(self._drive_tuning),
+            "joints": [spec.to_dict() for spec in self.list_joints()],
+            "positions": {str(key): float(value) for key, value in positions.items()},
+            "last_plan": last_plan,
+            "last_result": self._last_result,
+        }
+
+    def set_collision_check_enabled(self, enabled: bool) -> dict[str, bool]:
+        self._collision_check_enabled = bool(enabled)
+        self._last_result = {
+            "ok": True,
+            "code": "collision_check_enabled" if self._collision_check_enabled else "collision_check_disabled",
+            "collision_check_enabled": self._collision_check_enabled,
+        }
+        return {"collision_check_enabled": self._collision_check_enabled}
+
+    def apply_stable_drive_settings(
+        self,
+        settings: dict[str, dict[str, float]] | None = None,
+    ) -> dict[str, Any]:
+        clean_settings = self._clean_drive_settings(settings or DEFAULT_STABLE_DRIVE_SETTINGS)
+        applied = self.adapter.apply_drive_settings(clean_settings)
+        result = {
+            "ok": True,
+            "code": "stable_drive_applied",
+            "settings": {str(name): dict(values) for name, values in applied.items()},
+        }
+        self._drive_tuning = {"mode": "stable", "settings": result["settings"]}
+        self._last_result = result
+        return result
+
+    def plan_joint_targets(
+        self,
+        targets: dict[str, float],
+        options: PlanOptions | dict[str, Any] | None = None,
+    ) -> TrajectoryPlan:
+        plan_options = self._coerce_options(options)
+        clean_targets = {str(key): float(value) for key, value in targets.items()}
+        specs = {spec.name: spec for spec in self.list_joints()}
+        current = self.adapter.get_joint_positions()
+        for name, value in clean_targets.items():
+            spec = specs.get(name)
+            if spec is None:
+                raise JointControlError("unknown_joint", f"Unknown joint target: {name}", {"joint": name})
+            if value < spec.lower_limit or value > spec.upper_limit:
+                raise JointControlError(
+                    "joint_limit_exceeded",
+                    f"Joint {name} target {value} outside [{spec.lower_limit}, {spec.upper_limit}]",
+                    {"joint": name, "target": value, "lower_limit": spec.lower_limit, "upper_limit": spec.upper_limit},
+                )
+
+        start = {name: float(current.get(name, 0.0)) for name in clean_targets}
+        waypoint_count = self._waypoint_count(start, clean_targets, specs, plan_options)
+        if waypoint_count > int(plan_options.max_waypoints):
+            raise JointControlError(
+                "trajectory_too_long",
+                f"Trajectory requires {waypoint_count} waypoints, max is {plan_options.max_waypoints}",
+                {"waypoints": waypoint_count, "max_waypoints": plan_options.max_waypoints},
+            )
+        waypoints: list[dict[str, float]] = []
+        for index in range(1, waypoint_count + 1):
+            ratio = float(index) / float(waypoint_count)
+            waypoints.append(
+                {
+                    name: float(start[name] + (clean_targets[name] - start[name]) * ratio)
+                    for name in clean_targets
+                }
+            )
+        plan_id = f"plan_{next(self._plan_ids):04d}"
+        plan = TrajectoryPlan(
+            plan_id=plan_id,
+            start=start,
+            targets=clean_targets,
+            waypoints=waypoints,
+            options=plan_options,
+        )
+        self._plans[plan_id] = plan
+        self._status = "planned"
+        self._last_result = {"ok": True, "code": "planned", "plan_id": plan_id}
+        return plan
+
+    def check_joint_plan(self, plan_id: str) -> CollisionCheckResult:
+        plan = self._require_plan(plan_id)
+        self._status = "checking"
+        if not self._collision_check_enabled:
+            result = CollisionCheckResult(
+                plan_id=plan.plan_id,
+                safe=True,
+                code="collision_check_disabled",
+                message="Collision check is disabled",
+            )
+            self._mark_checked(plan, result)
+            return result
+
+        state = self.adapter.capture_state()
+        applied_any = False
+        try:
+            baseline_contact_keys = self._contact_keys(self.adapter.get_disallowed_contacts())
+            for index, waypoint in enumerate(plan.waypoints):
+                self.adapter.set_joint_targets(waypoint)
+                applied_any = True
+                self.adapter.step_simulation(plan.options.sim_steps_per_waypoint)
+                contacts = self._new_contacts(self.adapter.get_disallowed_contacts(), baseline_contact_keys)
+                if contacts:
+                    result = CollisionCheckResult(
+                        plan_id=plan.plan_id,
+                        safe=False,
+                        code="collision_detected",
+                        message=f"Trajectory collides at waypoint {index}",
+                        waypoint_index=index,
+                        contacts=[dict(contact) for contact in contacts],
+                    )
+                    self._mark_checked(plan, result)
+                    return result
+        except JointControlError:
+            raise
+        except Exception as exc:
+            result = CollisionCheckResult(
+                plan_id=plan.plan_id,
+                safe=False,
+                code="collision_check_unavailable",
+                message=str(exc),
+            )
+            self._mark_checked(plan, result)
+            return result
+        finally:
+            if applied_any:
+                self.adapter.restore_state(state)
+
+        result = CollisionCheckResult(
+            plan_id=plan.plan_id,
+            safe=True,
+            code="safe",
+            message="Trajectory collision check passed",
+        )
+        self._mark_checked(plan, result)
+        return result
+
+    def execute_joint_plan(self, plan_id: str) -> ExecutionResult:
+        plan = self._require_plan(plan_id)
+        if self._collision_check_enabled and not plan.checked:
+            raise JointControlError("plan_not_checked", f"Plan {plan_id} has not been collision checked")
+        if self._collision_check_enabled and plan.code == "collision_check_disabled":
+            raise JointControlError("plan_not_checked", f"Plan {plan_id} must be rechecked with collision checking enabled")
+        if self._collision_check_enabled and plan.safe is not True:
+            raise JointControlError("plan_not_safe", f"Plan {plan_id} is not safe", {"code": plan.code})
+        self._status = "executing"
+        self._stop_requested = False
+        executed = 0
+        baseline_contact_keys: set[tuple[str, str]] = set()
+        if self._collision_check_enabled:
+            try:
+                baseline_contact_keys = self._contact_keys(self.adapter.get_disallowed_contacts())
+            except Exception as exc:
+                result = ExecutionResult(
+                    plan_id=plan_id,
+                    ok=False,
+                    code="collision_check_unavailable",
+                    message=str(exc),
+                    waypoints_executed=0,
+                )
+                self._last_result = result.to_dict()
+                self._status = "failed"
+                return result
+        for waypoint in plan.waypoints:
+            if self._stop_requested:
+                result = ExecutionResult(plan_id=plan_id, ok=False, code="stopped", message="Motion stopped", waypoints_executed=executed)
+                self._last_result = result.to_dict()
+                self._status = "stopped"
+                return result
+            self.adapter.set_joint_targets(waypoint)
+            self.adapter.step_simulation(plan.options.sim_steps_per_waypoint)
+            if self._collision_check_enabled:
+                contacts = self._new_contacts(self.adapter.get_disallowed_contacts(), baseline_contact_keys)
+                if contacts:
+                    result = ExecutionResult(
+                        plan_id=plan_id,
+                        ok=False,
+                        code="collision_detected",
+                        message=f"Execution collision after waypoint {executed}",
+                        waypoints_executed=executed,
+                    )
+                    self._last_result = result.to_dict()
+                    self._status = "failed"
+                    return result
+            executed += 1
+        result = ExecutionResult(
+            plan_id=plan_id,
+            ok=True,
+            code="executed",
+            message="Trajectory executed",
+            waypoints_executed=executed,
+        )
+        self._last_result = result.to_dict()
+        self._status = "ready"
+        return result
+
+    def stop_joint_motion(self) -> ExecutionResult:
+        self._stop_requested = True
+        self._status = "stopped"
+        result = ExecutionResult(plan_id=None, ok=True, code="stopped", message="Stop requested")
+        self._last_result = result.to_dict()
+        return result
+
+    def _mark_checked(self, plan: TrajectoryPlan, result: CollisionCheckResult) -> None:
+        plan.checked = True
+        plan.safe = result.safe
+        plan.code = result.code
+        plan.message = result.message
+        plan.contacts = list(result.contacts)
+        plan.waypoint_index = result.waypoint_index
+        self._last_result = result.to_dict()
+        self._status = "checked_safe" if result.safe else "failed"
+
+    def _require_plan(self, plan_id: str) -> TrajectoryPlan:
+        plan = self._plans.get(str(plan_id))
+        if plan is None:
+            raise JointControlError("unknown_plan", f"Unknown joint plan: {plan_id}", {"plan_id": str(plan_id)})
+        return plan
+
+    def _coerce_options(self, options: PlanOptions | dict[str, Any] | None) -> PlanOptions:
+        if options is None:
+            return PlanOptions()
+        if isinstance(options, PlanOptions):
+            return options
+        return PlanOptions(**dict(options))
+
+    def _clean_drive_settings(self, settings: dict[str, dict[str, float]]) -> dict[str, dict[str, float]]:
+        specs = {spec.name: spec for spec in self.list_joints()}
+        clean_settings: dict[str, dict[str, float]] = {}
+        for name, values in settings.items():
+            if str(name) not in specs:
+                raise JointControlError("unknown_joint", f"Unknown joint drive setting: {name}", {"joint": str(name)})
+            clean_settings[str(name)] = {
+                "stiffness": float(values["stiffness"]),
+                "damping": float(values["damping"]),
+                "max_force": float(values["max_force"]),
+            }
+        return clean_settings
+
+    def _waypoint_count(
+        self,
+        start: dict[str, float],
+        targets: dict[str, float],
+        specs: dict[str, JointSpec],
+        options: PlanOptions,
+    ) -> int:
+        waypoint_count = 0
+        for name, target in targets.items():
+            delta = abs(float(target) - float(start[name]))
+            if delta <= 1e-12:
+                continue
+            spec = specs[name]
+            if spec.unit == "deg":
+                max_step = max(float(options.max_revolute_step_deg), 1e-9)
+            else:
+                max_step = max(float(options.max_prismatic_step_m), 1e-9)
+            waypoint_count = max(waypoint_count, int(math.ceil(delta / max_step)))
+        return waypoint_count
+
+    def _contact_keys(self, contacts: list[dict[str, Any]]) -> set[tuple[str, str]]:
+        return {self._contact_key(contact) for contact in contacts}
+
+    def _new_contacts(
+        self,
+        contacts: list[dict[str, Any]],
+        baseline_contact_keys: set[tuple[str, str]],
+    ) -> list[dict[str, Any]]:
+        return [dict(contact) for contact in contacts if self._contact_key(contact) not in baseline_contact_keys]
+
+    def _contact_key(self, contact: dict[str, Any]) -> tuple[str, str]:
+        body0 = self._contact_endpoint(contact, ("body0", "actor0", "path0", "prim0"))
+        body1 = self._contact_endpoint(contact, ("body1", "actor1", "path1", "prim1"))
+        if not body0 and not body1:
+            return ("", repr(sorted((str(key), str(value)) for key, value in dict(contact).items())))
+        return tuple(sorted((body0, body1)))
+
+    def _contact_endpoint(self, contact: dict[str, Any], names: tuple[str, ...]) -> str:
+        for name in names:
+            value = contact.get(name)
+            if value:
+                return str(value)
+        return ""

--- a/unilabos/sim/backends/isaac/managed.py
+++ b/unilabos/sim/backends/isaac/managed.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib import request
+
+
+class IsaacWorkerHealthError(RuntimeError):
+    pass
+
+
+@dataclass
+class ManagedIsaacWorkerConfig:
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 8091
+    scene: str | None = None
+    camera: str = "/World/Camera"
+    headless: bool = True
+    joint_control_ui: bool = False
+    warmup_steps: int = 2
+    rpc_timeout_s: float = 600.0
+    start_timeout_s: float = 120.0
+    conda_env: str | None = None
+    conda_executable: str = "conda"
+    python_executable: str = "python"
+    log_path: str | None = None
+    repo_root: Path = field(default_factory=Path.cwd)
+
+    @property
+    def endpoint(self) -> str:
+        return f"http://{self.host}:{int(self.port)}"
+
+
+class ManagedIsaacWorker:
+    def __init__(self, config: ManagedIsaacWorkerConfig) -> None:
+        self.config = config
+        self.process: subprocess.Popen | None = None
+        self._log_file: Any = None
+
+    @property
+    def endpoint(self) -> str:
+        return self.config.endpoint
+
+    def build_command(self) -> list[str]:
+        worker_args = [
+            "-m",
+            "unilabos.sim.backends.isaac.worker",
+            "--host",
+            self.config.host,
+            "--port",
+            str(int(self.config.port)),
+            "--headless" if self.config.headless else "--no-headless",
+        ]
+        if self.config.scene:
+            worker_args.extend(["--scene", str(self.config.scene)])
+        if self.config.joint_control_ui:
+            worker_args.append("--joint-control-ui")
+        worker_args.extend(
+            [
+                "--camera",
+                self.config.camera,
+                "--warmup-steps",
+                str(int(self.config.warmup_steps)),
+                "--rpc-timeout-s",
+                str(float(self.config.rpc_timeout_s)),
+            ]
+        )
+        if self.config.conda_env:
+            return [
+                self.config.conda_executable,
+                "run",
+                "--no-capture-output",
+                "-n",
+                self.config.conda_env,
+                self.config.python_executable,
+                *worker_args,
+            ]
+        return [self.config.python_executable, *worker_args]
+
+    def build_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        repo_root = str(self.config.repo_root)
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = repo_root if not existing else os.pathsep.join([repo_root, existing])
+        return env
+
+    def start(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            return
+        stdout = subprocess.DEVNULL
+        stderr = subprocess.DEVNULL
+        if self.config.log_path:
+            log_file = open(self.config.log_path, "a", encoding="utf-8")
+            self._log_file = log_file
+            stdout = log_file
+            stderr = subprocess.STDOUT
+        try:
+            self.process = subprocess.Popen(
+                self.build_command(),
+                cwd=str(self.config.repo_root),
+                env=self.build_env(),
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=True,
+            )
+            self.wait_until_healthy(timeout_s=self.config.start_timeout_s)
+        except Exception:
+            self.stop()
+            raise
+
+    def wait_until_healthy(self, timeout_s: float | None = None, interval_s: float = 1.0) -> None:
+        timeout = self.config.start_timeout_s if timeout_s is None else float(timeout_s)
+        deadline = time.monotonic() + timeout
+        last_error: BaseException | None = None
+        while time.monotonic() <= deadline:
+            if self.process is not None and self.process.poll() is not None:
+                raise IsaacWorkerHealthError(
+                    f"Isaac worker exited before becoming healthy with code {self.process.poll()}"
+                )
+            try:
+                payload = self._read_health()
+                if payload.get("ok") is True:
+                    return
+            except BaseException as exc:
+                last_error = exc
+            time.sleep(max(0.0, float(interval_s)))
+        raise IsaacWorkerHealthError(f"Isaac worker did not become healthy at {self.endpoint}: {last_error}")
+
+    def stop(self, timeout_s: float = 10.0) -> None:
+        process = self.process
+        if process is not None and process.poll() is None:
+            self._terminate_process(process)
+            try:
+                process.wait(timeout=timeout_s)
+            except subprocess.TimeoutExpired:
+                self._kill_process(process)
+                process.wait(timeout=timeout_s)
+        if self._log_file is not None:
+            self._log_file.close()
+            self._log_file = None
+
+    def _read_health(self) -> dict[str, Any]:
+        with request.urlopen(f"{self.endpoint}/health", timeout=5.0) as response:
+            import json
+
+            return dict(json.loads(response.read().decode("utf-8")))
+
+    def _terminate_process(self, process: subprocess.Popen) -> None:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except (AttributeError, ProcessLookupError):
+            process.terminate()
+
+    def _kill_process(self, process: subprocess.Popen) -> None:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (AttributeError, ProcessLookupError):
+            process.kill()

--- a/unilabos/sim/backends/isaac/worker.py
+++ b/unilabos/sim/backends/isaac/worker.py
@@ -9,6 +9,7 @@ import zlib
 from dataclasses import dataclass, field
 from typing import Any
 
+from unilabos.sim.backends.isaac.joint_control import DEFAULT_MVPPKUSHENGKE_JOINTS, JointControlService, JointSpec
 from unilabos.sim.backends.isaac.worker_http import ThreadingHTTPServer, make_handler
 
 
@@ -54,6 +55,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--warmup-steps", type=int, default=2)
     parser.add_argument("--rpc-timeout-s", type=float, default=600.0)
+    parser.add_argument("--joint-control-ui", action="store_true", default=False)
     return parser.parse_args(argv)
 
 
@@ -129,6 +131,27 @@ class IsaacWorkerState:
             )
         if op == "get_joint_states":
             return self.controller.get_joint_states(str(args["body_id"]))
+        if op == "list_joint_controls":
+            return _to_rpc_result(self.controller.list_joint_controls())
+        if op == "get_joint_control_state":
+            return _to_rpc_result(self.controller.get_joint_control_state())
+        if op == "plan_joint_targets":
+            return _to_rpc_result(
+                self.controller.plan_joint_targets(
+                    dict(args.get("targets") or {}),
+                    dict(args.get("options") or {}),
+                )
+            )
+        if op == "check_joint_plan":
+            return _to_rpc_result(self.controller.check_joint_plan(str(args["plan_id"])))
+        if op == "execute_joint_plan":
+            return _to_rpc_result(self.controller.execute_joint_plan(str(args["plan_id"])))
+        if op == "stop_joint_motion":
+            return _to_rpc_result(self.controller.stop_joint_motion())
+        if op == "set_collision_check_enabled":
+            return _to_rpc_result(self.controller.set_collision_check_enabled(bool(args.get("enabled"))))
+        if op == "apply_stable_drive_settings":
+            return _to_rpc_result(self.controller.apply_stable_drive_settings())
         if op == "apply_wrench":
             return self.controller.apply_wrench(str(args["body_id"]), dict(args.get("wrench") or {}))
         if op == "render":
@@ -137,13 +160,31 @@ class IsaacWorkerState:
         raise ValueError(f"Unsupported Isaac worker op: {op}")
 
 
+def _to_rpc_result(value: Any) -> Any:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, list):
+        return [_to_rpc_result(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _to_rpc_result(item) for key, item in value.items()}
+    return value
+
+
 class IsaacController:
-    def __init__(self, headless: bool, camera: str, robot_prim: str | None, warmup_steps: int = 2):
+    def __init__(
+        self,
+        headless: bool,
+        camera: str,
+        robot_prim: str | None,
+        warmup_steps: int = 2,
+        joint_control_ui: bool = False,
+    ):
         from isaacsim import SimulationApp
 
         self.app = SimulationApp({"headless": bool(headless)})
         self.camera = camera
         self.robot_prim = robot_prim
+        self.joint_control_ui = bool(joint_control_ui)
         self.scene_path: str | None = None
         self.commands: dict[str, dict[str, Any]] = {}
         self.observations: dict[str, dict[str, Any]] = {}
@@ -155,6 +196,12 @@ class IsaacController:
         self._stage = None
         self._last_dt = 0.0
         self._rgb_annotators: dict[tuple[str, int, int], Any] = {}
+        self._joint_control_service: JointControlService | None = None
+        self._joint_control_window: Any = None
+        self._joint_control_models: dict[str, Any] = {}
+        self._joint_control_status_model: Any = None
+        self._collision_mode_model: Any = None
+        self._init_ui_action_queue()
         for _ in range(max(0, int(warmup_steps))):
             self.app.update()
 
@@ -179,6 +226,13 @@ class IsaacController:
         for _ in range(2):
             self.app.update()
         self._stage = omni.usd.get_context().get_stage()
+        self._joint_control_service = None
+        try:
+            self.apply_stable_drive_settings()
+        except Exception as exc:
+            print(f"[isaac worker] stable drive auto-apply failed: {exc}", flush=True)
+        if self.joint_control_ui:
+            self._create_joint_control_ui()
 
     def get_observation(self, entity_id: str) -> dict[str, Any]:
         observation = dict(self.observations.get(entity_id, {}))
@@ -218,10 +272,35 @@ class IsaacController:
     def get_joint_states(self, body_id: str) -> dict[str, float]:
         return dict(self.joint_states.get(body_id, {}))
 
+    def list_joint_controls(self) -> list[dict[str, Any]]:
+        return [spec.to_dict() for spec in self._get_joint_control_service().list_joints()]
+
+    def get_joint_control_state(self) -> dict[str, Any]:
+        return self._get_joint_control_service().get_joint_control_state()
+
+    def plan_joint_targets(self, targets: dict[str, float], options: dict[str, Any] | None = None):
+        return self._get_joint_control_service().plan_joint_targets(targets, options)
+
+    def check_joint_plan(self, plan_id: str):
+        return self._get_joint_control_service().check_joint_plan(plan_id)
+
+    def execute_joint_plan(self, plan_id: str):
+        return self._get_joint_control_service().execute_joint_plan(plan_id)
+
+    def stop_joint_motion(self):
+        return self._get_joint_control_service().stop_joint_motion()
+
+    def set_collision_check_enabled(self, enabled: bool):
+        return self._get_joint_control_service().set_collision_check_enabled(bool(enabled))
+
+    def apply_stable_drive_settings(self):
+        return self._get_joint_control_service().apply_stable_drive_settings()
+
     def apply_wrench(self, body_id: str, wrench: dict[str, Any]) -> None:
         self.wrenches.append((str(body_id), dict(wrench)))
 
     def idle(self) -> None:
+        self._process_ui_actions()
         self.app.update()
 
     def render(self, camera: str, width: int, height: int) -> bytes:
@@ -236,6 +315,186 @@ class IsaacController:
 
     def close(self) -> None:
         self.app.close()
+
+    def _get_joint_control_service(self) -> JointControlService:
+        if self._joint_control_service is None:
+            self._joint_control_service = JointControlService(_IsaacJointControlAdapter(self))
+        return self._joint_control_service
+
+    def _collision_mode_text(self) -> str:
+        state = self.get_joint_control_state()
+        if bool(state.get("collision_check_enabled", True)):
+            return "Collision: ON - Check required"
+        return "Collision: OFF - Execute bypasses contact checks"
+
+    def _create_joint_control_ui(self) -> None:
+        try:
+            import omni.ui as ui
+
+            service = self._get_joint_control_service()
+            self._joint_control_window = ui.Window("UniLab Joint Control", width=460, height=620)
+            self._joint_control_models = {}
+            self._joint_control_status_model = ui.SimpleStringModel("Ready")
+            self._collision_mode_model = ui.SimpleStringModel(self._collision_mode_text())
+            with self._joint_control_window.frame:
+                with ui.VStack(spacing=6):
+                    ui.Label("UniLab Joint Control", height=24)
+                    ui.Label(f"Scene: {self.scene_path or 'not loaded'}", height=20)
+                    ui.Label("", model=self._collision_mode_model, height=24)
+                    ui.Label("", model=self._joint_control_status_model, height=20)
+                    for spec in service.list_joints():
+                        current = service.get_joint_control_state()["positions"].get(spec.name, 0.0)
+                        with ui.HStack(height=28):
+                            ui.Label(spec.name, width=120)
+                            model = ui.SimpleFloatModel(float(current))
+                            self._joint_control_models[spec.name] = model
+                            ui.FloatSlider(model=model, min=float(spec.lower_limit), max=float(spec.upper_limit))
+                            ui.Label(spec.unit, width=36)
+                    with ui.HStack(height=32):
+                        ui.Button("Plan", clicked_fn=self._ui_plan_joint_targets)
+                        ui.Button("Check", clicked_fn=self._ui_check_last_joint_plan)
+                        ui.Button("Execute", clicked_fn=self._ui_execute_last_joint_plan)
+                    with ui.HStack(height=32):
+                        ui.Button("Stop", clicked_fn=self._ui_stop_joint_motion)
+                        ui.Button("Reset Targets", clicked_fn=self._ui_reset_joint_targets)
+                    with ui.HStack(height=32):
+                        ui.Button("Collision ON/OFF", clicked_fn=self._ui_toggle_collision_check)
+                        ui.Button("Apply Stable Drive", clicked_fn=self._ui_apply_stable_drive)
+        except Exception as exc:
+            print(f"[isaac worker] joint control UI unavailable: {exc}", flush=True)
+
+    def _ui_targets(self) -> dict[str, float]:
+        targets = {}
+        for name, model in self._joint_control_models.items():
+            if hasattr(model, "get_value_as_float"):
+                targets[name] = float(model.get_value_as_float())
+            else:
+                targets[name] = float(model.as_float)
+        return targets
+
+    def _ui_set_status(self, text: str) -> None:
+        if self._joint_control_status_model is not None:
+            try:
+                self._joint_control_status_model.set_value(str(text))
+            except Exception:
+                pass
+
+    def _ui_set_collision_mode(self) -> None:
+        model = getattr(self, "_collision_mode_model", None)
+        if model is not None:
+            try:
+                model.set_value(self._collision_mode_text())
+            except Exception:
+                pass
+
+    def _init_ui_action_queue(self) -> None:
+        self._ui_action_queue: queue.Queue[tuple[str, Any]] = queue.Queue()
+
+    def _enqueue_ui_action(self, label: str, action: Any) -> None:
+        self._ui_set_status(f"{label} queued")
+        self._ui_action_queue.put((str(label), action))
+
+    def _process_ui_actions(self) -> bool:
+        processed = False
+        while True:
+            try:
+                label, action = self._ui_action_queue.get_nowait()
+            except queue.Empty:
+                return processed
+            try:
+                self._ui_set_status(f"{label} running")
+                action()
+            except Exception as exc:
+                self._ui_set_status(f"{label} failed: {exc}")
+            finally:
+                self._ui_action_queue.task_done()
+            processed = True
+
+    def _ui_last_plan_id(self) -> str | None:
+        state = self.get_joint_control_state()
+        last_plan = state.get("last_plan") or {}
+        return last_plan.get("plan_id")
+
+    def _ui_plan_joint_targets(self) -> None:
+        self._enqueue_ui_action("Plan", self._ui_plan_joint_targets_now)
+
+    def _ui_plan_joint_targets_now(self) -> None:
+        try:
+            plan = self.plan_joint_targets(self._ui_targets())
+            self._ui_set_status(f"Planned {plan.plan_id}: {len(plan.waypoints)} waypoints")
+        except Exception as exc:
+            self._ui_set_status(f"Plan failed: {exc}")
+
+    def _ui_check_last_joint_plan(self) -> None:
+        self._enqueue_ui_action("Check", self._ui_check_last_joint_plan_now)
+
+    def _ui_check_last_joint_plan_now(self) -> None:
+        try:
+            plan_id = self._ui_last_plan_id()
+            if not plan_id:
+                self._ui_set_status("No plan to check")
+                return
+            result = self.check_joint_plan(plan_id)
+            self._ui_set_status(f"Check {result.code}: {result.message}")
+        except Exception as exc:
+            self._ui_set_status(f"Check failed: {exc}")
+
+    def _ui_execute_last_joint_plan(self) -> None:
+        self._enqueue_ui_action("Execute", self._ui_execute_last_joint_plan_now)
+
+    def _ui_execute_last_joint_plan_now(self) -> None:
+        try:
+            plan_id = self._ui_last_plan_id()
+            if not plan_id:
+                self._ui_set_status("No plan to execute")
+                return
+            result = self.execute_joint_plan(plan_id)
+            self._ui_set_status(f"Execute {result.code}: {result.message}")
+        except Exception as exc:
+            self._ui_set_status(f"Execute failed: {exc}")
+
+    def _ui_toggle_collision_check(self) -> None:
+        self._enqueue_ui_action("Collision", self._ui_toggle_collision_check_now)
+
+    def _ui_toggle_collision_check_now(self) -> None:
+        try:
+            state = self.get_joint_control_state()
+            enabled = bool(state.get("collision_check_enabled", True))
+            result = self.set_collision_check_enabled(not enabled)
+            self._ui_set_collision_mode()
+            mode = "ON" if result.get("collision_check_enabled") else "OFF"
+            self._ui_set_status(f"Collision {mode}")
+        except Exception as exc:
+            self._ui_set_status(f"Collision toggle failed: {exc}")
+
+    def _ui_apply_stable_drive(self) -> None:
+        self._enqueue_ui_action("Stable Drive", self._ui_apply_stable_drive_now)
+
+    def _ui_apply_stable_drive_now(self) -> None:
+        try:
+            result = self.apply_stable_drive_settings()
+            self._ui_set_status(f"Stable drive applied: {len(result.get('settings', {}))} joints")
+        except Exception as exc:
+            self._ui_set_status(f"Stable drive failed: {exc}")
+
+    def _ui_stop_joint_motion(self) -> None:
+        self._enqueue_ui_action("Stop", self._ui_stop_joint_motion_now)
+
+    def _ui_stop_joint_motion_now(self) -> None:
+        result = self.stop_joint_motion()
+        self._ui_set_status(result.message)
+
+    def _ui_reset_joint_targets(self) -> None:
+        self._enqueue_ui_action("Reset", self._ui_reset_joint_targets_now)
+
+    def _ui_reset_joint_targets_now(self) -> None:
+        positions = self.get_joint_control_state().get("positions", {})
+        for name, model in self._joint_control_models.items():
+            try:
+                model.set_value(float(positions.get(name, 0.0)))
+            except Exception:
+                pass
+        self._ui_set_status("Targets reset")
 
     def _query_prim_pose(self, entity_id: str) -> dict[str, Any] | None:
         if self._stage is None or not entity_id.startswith("/"):
@@ -345,6 +604,188 @@ class IsaacController:
             self.render_error = f"camera setup failed: {exc}"
 
 
+class _IsaacJointControlAdapter:
+    def __init__(self, controller: IsaacController) -> None:
+        self.controller = controller
+
+    def list_joint_specs(self) -> list[JointSpec]:
+        if self.controller._stage is None:
+            return list(DEFAULT_MVPPKUSHENGKE_JOINTS)
+        return [self._spec_from_stage(default_spec) for default_spec in DEFAULT_MVPPKUSHENGKE_JOINTS]
+
+    def get_joint_positions(self) -> dict[str, float]:
+        positions: dict[str, float] = {}
+        fallback = self.controller.joint_states.get("joint_control", {})
+        for spec in self.list_joint_specs():
+            value = self._get_drive_target(spec)
+            positions[spec.name] = float(fallback.get(spec.name, value))
+        return positions
+
+    def capture_state(self) -> dict[str, float]:
+        return self.get_joint_positions()
+
+    def restore_state(self, state: dict[str, float]) -> None:
+        self.set_joint_targets({str(key): float(value) for key, value in dict(state).items()})
+        self.step_simulation(1)
+
+    def set_joint_targets(self, targets: dict[str, float]) -> None:
+        clean_targets = {str(key): float(value) for key, value in targets.items()}
+        self.controller.joint_states["joint_control"] = dict(clean_targets)
+        if self.controller._stage is None:
+            return
+        specs = {spec.name: spec for spec in self.list_joint_specs()}
+        for name, value in clean_targets.items():
+            spec = specs[name]
+            prim = self.controller._stage.GetPrimAtPath(spec.path)
+            if not prim or not prim.IsValid():
+                raise RuntimeError(f"Joint prim not found: {spec.path}")
+            attr = prim.GetAttribute(f"drive:{spec.drive_axis}:physics:targetPosition")
+            if not attr:
+                from pxr import UsdPhysics
+
+                drive = UsdPhysics.DriveAPI.Apply(prim, spec.drive_axis)
+                attr = drive.CreateTargetPositionAttr()
+            attr.Set(float(value))
+
+    def step_simulation(self, steps: int) -> None:
+        for _ in range(max(0, int(steps))):
+            self.controller.app.update()
+
+    def get_disallowed_contacts(self) -> list[dict[str, Any]]:
+        report = self._read_contact_report()
+        return self._parse_contacts(report)
+
+    def apply_drive_settings(self, settings: dict[str, dict[str, float]]) -> dict[str, dict[str, float]]:
+        applied: dict[str, dict[str, float]] = {}
+        specs = {spec.name: spec for spec in self.list_joint_specs()}
+        for name, values in settings.items():
+            spec = specs[str(name)]
+            clean_values = {
+                "stiffness": float(values["stiffness"]),
+                "damping": float(values["damping"]),
+                "max_force": float(values["max_force"]),
+            }
+            applied[spec.name] = clean_values
+            if self.controller._stage is None:
+                continue
+            prim = self.controller._stage.GetPrimAtPath(spec.path)
+            if not prim or not prim.IsValid():
+                raise RuntimeError(f"Joint prim not found: {spec.path}")
+            self._set_drive_attr(prim, spec.drive_axis, "stiffness", clean_values["stiffness"])
+            self._set_drive_attr(prim, spec.drive_axis, "damping", clean_values["damping"])
+            self._set_drive_attr(prim, spec.drive_axis, "maxForce", clean_values["max_force"])
+        return applied
+
+    def _spec_from_stage(self, default_spec: JointSpec) -> JointSpec:
+        prim = self.controller._stage.GetPrimAtPath(default_spec.path)
+        if not prim or not prim.IsValid():
+            return default_spec
+        body0 = self._first_target(prim, "physics:body0") or default_spec.body0
+        body1 = self._first_target(prim, "physics:body1") or default_spec.body1
+        lower = self._attr_float(prim, "physics:lowerLimit", default_spec.lower_limit)
+        upper = self._attr_float(prim, "physics:upperLimit", default_spec.upper_limit)
+        drive_axis = "angular" if "Revolute" in prim.GetTypeName() else "linear"
+        joint_type = "revolute" if drive_axis == "angular" else "prismatic"
+        unit = "deg" if drive_axis == "angular" else "m"
+        return JointSpec(
+            name=default_spec.name,
+            path=default_spec.path,
+            joint_type=joint_type,
+            drive_axis=drive_axis,
+            unit=unit,
+            lower_limit=lower,
+            upper_limit=upper,
+            body0=body0,
+            body1=body1,
+        )
+
+    def _get_drive_target(self, spec: JointSpec) -> float:
+        if self.controller._stage is None:
+            return 0.0
+        prim = self.controller._stage.GetPrimAtPath(spec.path)
+        if not prim or not prim.IsValid():
+            return 0.0
+        attr = prim.GetAttribute(f"drive:{spec.drive_axis}:physics:targetPosition")
+        if not attr:
+            return 0.0
+        value = attr.Get()
+        return 0.0 if value is None else float(value)
+
+    def _set_drive_attr(self, prim: Any, drive_axis: str, name: str, value: float) -> None:
+        attr = prim.GetAttribute(f"drive:{drive_axis}:physics:{name}")
+        if not attr:
+            from pxr import UsdPhysics
+
+            drive = UsdPhysics.DriveAPI.Apply(prim, drive_axis)
+            if name == "stiffness":
+                attr = drive.CreateStiffnessAttr()
+            elif name == "damping":
+                attr = drive.CreateDampingAttr()
+            elif name == "maxForce":
+                attr = drive.CreateMaxForceAttr()
+            else:
+                raise RuntimeError(f"Unsupported drive attr: {name}")
+        attr.Set(float(value))
+
+    def _read_contact_report(self) -> Any:
+        try:
+            import omni.physx
+
+            interface = omni.physx.get_physx_simulation_interface()
+            if hasattr(interface, "get_full_contact_report"):
+                return interface.get_full_contact_report()
+            if hasattr(interface, "get_contact_report"):
+                return interface.get_contact_report()
+        except Exception as exc:
+            raise RuntimeError(f"contact report unavailable: {exc}") from exc
+        raise RuntimeError("contact report unavailable: no supported PhysX contact API")
+
+    def _parse_contacts(self, report: Any) -> list[dict[str, Any]]:
+        if report is None:
+            return []
+        if isinstance(report, (list, tuple)):
+            contacts: list[dict[str, Any]] = []
+            for item in report:
+                contacts.extend(self._parse_contacts(item))
+            return contacts
+        headers = getattr(report, "contact_headers", None) or getattr(report, "headers", None)
+        if headers is not None:
+            return self._parse_contacts(headers)
+        body0 = self._object_path(report, ("body0", "actor0", "path0", "prim0"))
+        body1 = self._object_path(report, ("body1", "actor1", "path1", "prim1"))
+        if body0 or body1:
+            return [{"body0": body0 or "", "body1": body1 or ""}]
+        try:
+            if len(report) == 0:
+                return []
+        except Exception:
+            pass
+        if bool(report) is False:
+            return []
+        raise RuntimeError(f"contact report format unsupported: {type(report).__name__}")
+
+    def _first_target(self, prim: Any, rel_name: str) -> str | None:
+        rel = prim.GetRelationship(rel_name)
+        if not rel:
+            return None
+        targets = rel.GetTargets()
+        return str(targets[0]) if targets else None
+
+    def _attr_float(self, prim: Any, attr_name: str, default: float) -> float:
+        attr = prim.GetAttribute(attr_name)
+        if not attr:
+            return float(default)
+        value = attr.Get()
+        return float(default) if value is None else float(value)
+
+    def _object_path(self, item: Any, names: tuple[str, ...]) -> str | None:
+        for name in names:
+            value = getattr(item, name, None)
+            if value:
+                return str(value)
+        return None
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     controller = IsaacController(
@@ -352,6 +793,7 @@ def main(argv: list[str] | None = None) -> int:
         camera=args.camera,
         robot_prim=args.robot_prim,
         warmup_steps=args.warmup_steps,
+        joint_control_ui=args.joint_control_ui,
     )
     if args.scene:
         controller.load_scene(args.scene)

--- a/unilabos/sim/backends/isaac_bridge.py
+++ b/unilabos/sim/backends/isaac_bridge.py
@@ -59,6 +59,37 @@ class IsaacBridgeBackend:
         result = self._rpc("get_joint_states", {"body_id": str(body_id)}) or {}
         return {str(key): float(value) for key, value in dict(result).items()}
 
+    def list_joint_controls(self) -> list[dict[str, Any]]:
+        result = self._rpc("list_joint_controls") or []
+        return [dict(item) for item in result]
+
+    def get_joint_control_state(self) -> dict[str, Any]:
+        return dict(self._rpc("get_joint_control_state") or {})
+
+    def plan_joint_targets(self, targets: dict[str, float], options: dict[str, Any] | None = None) -> dict[str, Any]:
+        return dict(
+            self._rpc(
+                "plan_joint_targets",
+                {"targets": dict(targets), "options": dict(options or {})},
+            )
+            or {}
+        )
+
+    def check_joint_plan(self, plan_id: str) -> dict[str, Any]:
+        return dict(self._rpc("check_joint_plan", {"plan_id": str(plan_id)}) or {})
+
+    def execute_joint_plan(self, plan_id: str) -> dict[str, Any]:
+        return dict(self._rpc("execute_joint_plan", {"plan_id": str(plan_id)}) or {})
+
+    def stop_joint_motion(self) -> dict[str, Any]:
+        return dict(self._rpc("stop_joint_motion") or {})
+
+    def set_collision_check_enabled(self, enabled: bool) -> dict[str, Any]:
+        return dict(self._rpc("set_collision_check_enabled", {"enabled": bool(enabled)}) or {})
+
+    def apply_stable_drive_settings(self) -> dict[str, Any]:
+        return dict(self._rpc("apply_stable_drive_settings") or {})
+
     def apply_wrench(self, body_id: str, wrench: dict[str, Any]) -> None:
         self._rpc("apply_wrench", {"body_id": str(body_id), "wrench": dict(wrench)})
 


### PR DESCRIPTION
## 概述

  本 PR 为 Uni-Lab-OS 增加 Isaac 托管运行能力，并补齐 Isaac worker 内的关节控制链路，使 edge 可以启动并管理 Isaac worker，随后通过 RPC/bridge 使用
  Isaac 物理与关节控制能力。

  ## 主要改动

  - 增加 managed Isaac worker 模式：edge 启动 worker、等待 `/health`、注入 `physics_endpoint`，并在退出时清理进程。
  - 增加 Isaac 关节控制核心，支持关节发现、目标规划、碰撞检查门控、执行与停止状态。
  - 扩展 Isaac worker / bridge RPC：关节列表、状态查询、轨迹规划、轨迹检查、执行与停止。
  - 增加 `--isaac_managed`、worker 启动参数和 `--isaac_joint_control_ui` 等 CLI/backend wiring。
