### PR TITLE
feat(sim): add RViz simulation backends for cytomat/shaker/plate reader/peeler/sealer

### DIFF
--- a/unilabos/devices/cytomat/liconic_stx110_rviz_backend.py
+++ b/unilabos/devices/cytomat/liconic_stx110_rviz_backend.py
@@ -1,0 +1,205 @@
+"""
+LiCONiC STX110 仿真 RViz Backend
+
+设备功能：转盘式板存储孵育器（5 个货架位，可加热）
+模型完整度：⭐⭐⭐⭐⭐ — 具有 base + carousel 两个独立 mesh，
+            以及已定义的 carousel_joint（continuous，绕 Z 轴旋转）。
+
+仿真逻辑：
+  - load_plate(slot)   → 转盘旋转至对应插槽角度
+  - unload_plate(slot) → 转盘旋转至出口角度
+  - set_temperature    → 仅打印（无运动）
+  - get_temperature    → 返回设定值
+
+STX110 共 5 个货架，角度间隔 72°（2π/5），slot 编号 1–5。
+
+依赖：
+    unilabos/devices/ros_dev/simple_joint_publisher_node.py
+"""
+
+import asyncio
+import math
+import threading
+from typing import Optional
+
+import rclpy
+
+from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+try:
+    from pylabrobot.heating_shaking.backend import HeaterShakerBackend
+    _PLR_AVAILABLE = True
+except ImportError:
+    # 未安装 pylabrobot 时退化为哑类，方便独立测试
+    class HeaterShakerBackend:  # type: ignore
+        async def setup(self): pass
+        async def stop(self): pass
+    _PLR_AVAILABLE = False
+
+
+# 5 个货架的角度（弧度），从正前方开始逆时针
+_SLOT_ANGLES = {i: math.radians((i - 1) * 72) for i in range(1, 6)}
+# 出口/传输窗口角度（正前方）
+_TRANSFER_ANGLE = 0.0
+# 转盘旋转速度（rad/s）
+_CAROUSEL_SPEED = 0.8
+
+
+class LiconicStx110RvizBackend(HeaterShakerBackend):
+    """
+    LiCONiC STX110 孵育器仿真 Backend。
+
+    在 RViz 中驱动转盘旋转，模拟板的存取动作。
+
+    Parameters
+    ----------
+    device_id : str
+        与 URDF 中 robot name 一致，默认 "liconic_stx110"。
+    """
+
+    def __init__(self, device_id: str = "liconic_stx110"):
+        if _PLR_AVAILABLE:
+            super().__init__()
+        self.device_id = device_id
+        self._target_temperature: float = 37.0
+        self._current_temperature: float = 22.0
+        self._shaking: bool = False
+
+        self._publisher: Optional[SimpleJointPublisher] = None
+        self._executor = None
+        self._executor_thread = None
+
+    # ------------------------------------------------------------------
+    # MachineBackend interface
+    # ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        if not rclpy.ok():
+            rclpy.init()
+
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=["0_carousel_joint"],
+            rate=50,
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(
+            target=self._executor.spin, daemon=True
+        )
+        self._executor_thread.start()
+
+        # 复位到出口位置
+        self._publisher.set_immediate({"0_carousel_joint": _TRANSFER_ANGLE})
+        print(f"[{self.device_id}] Setup complete. Carousel at transfer position.")
+
+    async def stop(self) -> None:
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor_thread and self._executor_thread.is_alive():
+            self._executor.shutdown()
+        print(f"[{self.device_id}] Stopped.")
+
+    # ------------------------------------------------------------------
+    # Incubator / storage operations
+    # ------------------------------------------------------------------
+
+    async def load_plate(self, slot: int) -> None:
+        """
+        将转盘旋转使 slot 对准传输窗口，模拟机器人放板。
+
+        Parameters
+        ----------
+        slot : int
+            目标货架编号（1–5）。
+        """
+        if slot not in _SLOT_ANGLES:
+            raise ValueError(f"Invalid slot {slot}. Must be 1–5.")
+
+        angle = _SLOT_ANGLES[slot]
+        print(f"[{self.device_id}] Rotating carousel to slot {slot} (angle={math.degrees(angle):.1f}°)")
+        await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_carousel_joint": angle}, speed=_CAROUSEL_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Slot {slot} aligned. Ready for plate load.")
+
+    async def unload_plate(self, slot: int) -> None:
+        """
+        旋转转盘取出指定 slot 的板。
+
+        Parameters
+        ----------
+        slot : int
+            目标货架编号（1–5）。
+        """
+        if slot not in _SLOT_ANGLES:
+            raise ValueError(f"Invalid slot {slot}. Must be 1–5.")
+
+        angle = _SLOT_ANGLES[slot]
+        print(f"[{self.device_id}] Rotating carousel to slot {slot} for unload (angle={math.degrees(angle):.1f}°)")
+        await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_carousel_joint": angle}, speed=_CAROUSEL_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Plate unloaded from slot {slot}.")
+        # 回到出口
+        await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_carousel_joint": _TRANSFER_ANGLE}, speed=_CAROUSEL_SPEED
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # HeaterShakerBackend interface（孵育器以加热为主，振荡为辅）
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_locking(self) -> bool:
+        return False
+
+    async def lock_plate(self) -> None:
+        print(f"[{self.device_id}] Lock plate (simulated).")
+
+    async def unlock_plate(self) -> None:
+        print(f"[{self.device_id}] Unlock plate (simulated).")
+
+    async def start_shaking(self, speed: float) -> None:
+        """STX110 本身不振荡，此处仅打印。"""
+        self._shaking = True
+        print(f"[{self.device_id}] Start shaking at {speed} RPM (simulated, no motion).")
+
+    async def shake(self, speed: float, *args, **kwargs) -> None:
+        """ShakerBackend 抽象接口。STX110 不振荡，委托给 start_shaking。"""
+        await self.start_shaking(speed)
+
+    async def stop_shaking(self) -> None:
+        self._shaking = False
+        print(f"[{self.device_id}] Stop shaking (simulated).")
+
+    # TemperatureControllerBackend interface
+    @property
+    def supports_active_cooling(self) -> bool:
+        return False
+
+    async def set_temperature(self, temperature: float) -> None:
+        self._target_temperature = temperature
+        print(f"[{self.device_id}] Set temperature → {temperature}°C (simulated).")
+
+    async def get_current_temperature(self) -> float:
+        # 简单模拟：以 0.5°C/s 向目标靠近
+        diff = self._target_temperature - self._current_temperature
+        self._current_temperature += min(abs(diff), 0.5) * (1 if diff > 0 else -1)
+        return round(self._current_temperature, 1)
+
+    async def deactivate(self) -> None:
+        self._target_temperature = 22.0
+        print(f"[{self.device_id}] Temperature deactivated.")
+
+    def serialize(self) -> dict:
+        return {"type": self.__class__.__name__, "device_id": self.device_id}

--- a/unilabos/devices/cytomat/thermo_cytomat2c_rviz_backend.py
+++ b/unilabos/devices/cytomat/thermo_cytomat2c_rviz_backend.py
@@ -1,0 +1,220 @@
+"""
+Thermo Fisher Cytomat 2C 仿真 RViz Backend
+
+设备功能：微孔板自动存储孵育器（内置加热 / 可选制冷）
+模型完整度：⭐⭐⭐⭐ — 单体 mesh（机身）+ XACRO 中预留了注释关节：
+            • 0_door_joint    revolute Z  [0, 1.93 rad]  — 前门开合
+            • 0_reardoor_joint prismatic Z [0, -0.13 m]  — 后门推拉（传输口）
+
+仿真逻辑：
+  load_plate()   → 后门打开 → 模拟等待放板 → 后门关闭
+  unload_plate() → 后门打开 → 模拟等待取板 → 后门关闭
+  open_door()    → 前门旋转打开（人工访问）
+  close_door()   → 前门关闭
+
+依赖：
+    unilabos/devices/ros_dev/simple_joint_publisher_node.py
+
+注意：XACRO 中门关节已预留，但门的 mesh 文件当前不存在，
+      关节将发布关节状态但在 RViz 中无对应可视化几何体。
+"""
+
+import asyncio
+import threading
+from typing import Optional
+
+import rclpy
+
+from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+try:
+    from pylabrobot.heating_shaking.backend import HeaterShakerBackend
+    _PLR_AVAILABLE = True
+except ImportError:
+    class HeaterShakerBackend:  # type: ignore
+        async def setup(self): pass
+        async def stop(self): pass
+    _PLR_AVAILABLE = False
+
+
+# 关节参数
+_FRONT_DOOR_OPEN  = 1.93   # rad（约 110°）
+_FRONT_DOOR_CLOSE = 0.0
+_REAR_DOOR_OPEN   = -0.13  # m（向 -Z 推出 130 mm）
+_REAR_DOOR_CLOSE  = 0.0
+
+_DOOR_ROT_SPEED   = 0.8    # rad/s
+_DOOR_LIN_SPEED   = 0.03   # m/s
+
+# 模拟板进出等待时间（秒）
+_TRANSFER_DWELL   = 1.5
+
+
+class ThermoFisherCytomat2CRvizBackend(HeaterShakerBackend):
+    """
+    Thermo Fisher Cytomat 2C 孵育器仿真 Backend。
+
+    Parameters
+    ----------
+    device_id : str
+        与 URDF robot name 对应，默认 "thermo_cytomat2c"。
+    """
+
+    def __init__(self, device_id: str = "thermo_cytomat2c"):
+        if _PLR_AVAILABLE:
+            super().__init__()
+        self.device_id = device_id
+        self._target_temperature: float = 37.0
+        self._current_temperature: float = 22.0
+        self._shaking: bool = False
+
+        self._publisher: Optional[SimpleJointPublisher] = None
+        self._executor = None
+        self._executor_thread = None
+
+    # ------------------------------------------------------------------
+    # MachineBackend interface
+    # ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        if not rclpy.ok():
+            rclpy.init()
+
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=["0_door_joint", "0_reardoor_joint"],
+            rate=50,
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(
+            target=self._executor.spin, daemon=True
+        )
+        self._executor_thread.start()
+
+        self._publisher.set_immediate({
+            "0_door_joint": _FRONT_DOOR_CLOSE,
+            "0_reardoor_joint": _REAR_DOOR_CLOSE,
+        })
+        print(f"[{self.device_id}] Setup complete. Both doors closed.")
+
+    async def stop(self) -> None:
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor_thread and self._executor_thread.is_alive():
+            self._executor.shutdown()
+        print(f"[{self.device_id}] Stopped.")
+
+    # ------------------------------------------------------------------
+    # Incubator operations（PLR 通过直接命令驱动，这里封装为动画操作）
+    # ------------------------------------------------------------------
+
+    async def load_plate(self) -> None:
+        """模拟从后传输口放入一块板。"""
+        loop = asyncio.get_event_loop()
+
+        print(f"[{self.device_id}] Opening rear transfer door...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_reardoor_joint": _REAR_DOOR_OPEN}, speed=_DOOR_LIN_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Transfer window open. Loading plate...")
+        await asyncio.sleep(_TRANSFER_DWELL)
+
+        print(f"[{self.device_id}] Closing rear transfer door...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_reardoor_joint": _REAR_DOOR_CLOSE}, speed=_DOOR_LIN_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Plate loaded.")
+
+    async def unload_plate(self) -> None:
+        """模拟从后传输口取出一块板。"""
+        loop = asyncio.get_event_loop()
+
+        print(f"[{self.device_id}] Opening rear transfer door for unload...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_reardoor_joint": _REAR_DOOR_OPEN}, speed=_DOOR_LIN_SPEED
+            ),
+        )
+        await asyncio.sleep(_TRANSFER_DWELL)
+
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_reardoor_joint": _REAR_DOOR_CLOSE}, speed=_DOOR_LIN_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Plate unloaded.")
+
+    async def open_door(self) -> None:
+        """打开前门（人工访问/维护）。"""
+        loop = asyncio.get_event_loop()
+        print(f"[{self.device_id}] Opening front door...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_door_joint": _FRONT_DOOR_OPEN}, speed=_DOOR_ROT_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Front door open.")
+
+    async def close_door(self) -> None:
+        """关闭前门。"""
+        loop = asyncio.get_event_loop()
+        print(f"[{self.device_id}] Closing front door...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"0_door_joint": _FRONT_DOOR_CLOSE}, speed=_DOOR_ROT_SPEED
+            ),
+        )
+        print(f"[{self.device_id}] Front door closed.")
+
+    # ------------------------------------------------------------------
+    # HeaterShakerBackend interface
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_locking(self) -> bool:
+        return False
+
+    async def lock_plate(self) -> None:
+        print(f"[{self.device_id}] Lock plate (simulated).")
+
+    async def unlock_plate(self) -> None:
+        print(f"[{self.device_id}] Unlock plate (simulated).")
+
+    async def start_shaking(self, speed: float) -> None:
+        self._shaking = True
+        print(f"[{self.device_id}] Shaking at {speed} RPM (simulated, no motion).")
+
+    async def stop_shaking(self) -> None:
+        self._shaking = False
+        print(f"[{self.device_id}] Stop shaking.")
+
+    @property
+    def supports_active_cooling(self) -> bool:
+        return False
+
+    async def set_temperature(self, temperature: float) -> None:
+        self._target_temperature = temperature
+        print(f"[{self.device_id}] Set temperature → {temperature}°C (simulated).")
+
+    async def get_current_temperature(self) -> float:
+        diff = self._target_temperature - self._current_temperature
+        self._current_temperature += min(abs(diff), 0.5) * (1 if diff > 0 else -1)
+        return round(self._current_temperature, 1)
+
+    async def deactivate(self) -> None:
+        self._target_temperature = 22.0
+        print(f"[{self.device_id}] Temperature deactivated.")
+
+    def serialize(self) -> dict:
+        return {"type": self.__class__.__name__, "device_id": self.device_id}

--- a/unilabos/devices/heaterstirrer/qinstruments_bioshake_rviz_backend.py
+++ b/unilabos/devices/heaterstirrer/qinstruments_bioshake_rviz_backend.py
@@ -1,0 +1,196 @@
+"""
+QInstruments BioShake 仿真 RViz Backend
+
+适用型号：BioShake 3000T / BioShake 5000 / BioShake Q1
+设备功能：加热振荡器（orbiting shaker + 温控）
+模型完整度：⭐⭐⭐ — 单体 mesh，无预设关节。
+            仿真在 XACRO 中动态添加 "shake_joint"（绕 Z 轴连续旋转，
+            模拟偏心振荡）。
+
+仿真逻辑：
+  - start_shaking(rpm)  → shake_joint 持续旋转（速度 = rpm/60 * 2π rad/s）
+  - stop_shaking()      → 旋转停止，复位到 0
+  - lock_plate()        → 打印（无运动）
+  - set_temperature()   → 打印（无运动）
+
+注意：BioShake 实为轨道振荡（偏心圆周运动），单关节旋转是近似仿真。
+
+依赖：
+    unilabos/devices/ros_dev/simple_joint_publisher_node.py
+"""
+
+import asyncio
+import math
+import threading
+import time
+from typing import Optional
+
+import rclpy
+
+from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+try:
+    from pylabrobot.heating_shaking.backend import HeaterShakerBackend
+    _PLR_AVAILABLE = True
+except ImportError:
+    class HeaterShakerBackend:  # type: ignore
+        async def setup(self): pass
+        async def stop(self): pass
+    _PLR_AVAILABLE = False
+
+
+# 每次振荡动画的角度增量（弧度），仿真轨道振荡
+_SHAKE_STEP = math.radians(30)
+
+
+class QInstrumentsBioShakeRvizBackend(HeaterShakerBackend):
+    """
+    QInstruments BioShake 振荡器仿真 Backend。
+
+    通过 shake_joint 绕 Z 轴连续旋转来模拟振荡。
+
+    Parameters
+    ----------
+    device_id : str
+        与 URDF robot name 对应，可选 "qinstruments_bioshake_3000t" /
+        "qinstruments_bioshake_5000" / "qinstruments_bioshake_q1"。
+    """
+
+    def __init__(self, device_id: str = "qinstruments_bioshake_3000t"):
+        if _PLR_AVAILABLE:
+            super().__init__()
+        self.device_id = device_id
+        self._rpm: float = 0.0
+        self._target_temperature: float = 25.0
+        self._current_temperature: float = 22.0
+        self._shaking: bool = False
+        self._plate_locked: bool = False
+
+        self._publisher: Optional[SimpleJointPublisher] = None
+        self._executor = None
+        self._executor_thread = None
+        self._shake_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # MachineBackend interface
+    # ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        if not rclpy.ok():
+            rclpy.init()
+
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=["shake_joint"],
+            rate=50,
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(
+            target=self._executor.spin, daemon=True
+        )
+        self._executor_thread.start()
+
+        self._publisher.set_immediate({"shake_joint": 0.0})
+        print(f"[{self.device_id}] Setup complete.")
+
+    async def stop(self) -> None:
+        await self.stop_shaking()
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor_thread and self._executor_thread.is_alive():
+            self._executor.shutdown()
+        print(f"[{self.device_id}] Stopped.")
+
+    # ------------------------------------------------------------------
+    # ShakerBackend interface
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_locking(self) -> bool:
+        return True
+
+    async def lock_plate(self) -> None:
+        self._plate_locked = True
+        print(f"[{self.device_id}] Plate locked (simulated).")
+
+    async def unlock_plate(self) -> None:
+        self._plate_locked = False
+        print(f"[{self.device_id}] Plate unlocked (simulated).")
+
+    async def start_shaking(self, speed: float) -> None:
+        """
+        开始振荡。
+
+        Parameters
+        ----------
+        speed : float
+            转速（RPM）。
+        """
+        if self._shaking:
+            await self.stop_shaking()
+
+        self._rpm = speed
+        self._shaking = True
+        self._stop_event.clear()
+
+        # 后台线程持续递增 shake_joint 角度
+        self._shake_thread = threading.Thread(
+            target=self._shake_loop, daemon=True
+        )
+        self._shake_thread.start()
+        print(f"[{self.device_id}] Start shaking at {speed} RPM.")
+
+    async def stop_shaking(self) -> None:
+        self._shaking = False
+        self._stop_event.set()
+        if self._shake_thread and self._shake_thread.is_alive():
+            self._shake_thread.join(timeout=2.0)
+        if self._publisher:
+            self._publisher.move_to({"shake_joint": 0.0}, speed=math.pi)
+        print(f"[{self.device_id}] Stop shaking.")
+
+    # ------------------------------------------------------------------
+    # TemperatureControllerBackend interface
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_active_cooling(self) -> bool:
+        return False
+
+    async def set_temperature(self, temperature: float) -> None:
+        self._target_temperature = temperature
+        print(f"[{self.device_id}] Set temperature → {temperature}°C (simulated).")
+
+    async def get_current_temperature(self) -> float:
+        diff = self._target_temperature - self._current_temperature
+        self._current_temperature += min(abs(diff), 0.3) * (1 if diff > 0 else -1)
+        return round(self._current_temperature, 1)
+
+    async def deactivate(self) -> None:
+        self._target_temperature = 22.0
+        print(f"[{self.device_id}] Temperature deactivated.")
+
+    def serialize(self) -> dict:
+        return {"type": self.__class__.__name__, "device_id": self.device_id}
+
+    # ------------------------------------------------------------------
+    # Internal shake loop
+    # ------------------------------------------------------------------
+
+    def _shake_loop(self) -> None:
+        """后台线程：按 RPM 持续累加 shake_joint 角度，模拟轨道振荡。"""
+        if self._publisher is None:
+            return
+        angle = self._publisher.get_position("shake_joint")
+        # RPM → rad/s
+        omega = self._rpm / 60.0 * 2 * math.pi
+        dt = 0.02  # 50 Hz
+
+        while not self._stop_event.is_set():
+            angle += omega * dt
+            # 折叠到 [-π, π] 防止溢出
+            angle = (angle + math.pi) % (2 * math.pi) - math.pi
+            self._publisher.set_immediate({"shake_joint": angle})
+            time.sleep(dt)

--- a/unilabos/devices/platereader/clariostar_rviz_backend.py
+++ b/unilabos/devices/platereader/clariostar_rviz_backend.py
@@ -1,0 +1,195 @@
+"""
+BMG Labtech CLARIOstar Plus 仿真 RViz Backend
+
+设备功能：多模式酶标仪（吸光度 / 荧光 / 化学发光）
+模型完整度：⭐⭐⭐ — 单体 mesh（base）+ socketTypeGenericSbsFootprint 定义了
+            板的坐标位置（xyz="-0.09 -0.304 0.08"）。
+
+仿真逻辑：
+  - open()  → tray_joint（棱柱关节）伸出，板托平移至读取位外侧 130 mm
+  - close() → tray_joint 缩回到 0，板进入光学测量腔
+  - read_absorbance / read_fluorescence / read_luminescence
+            → open → 模拟等待 → close → 返回随机占位数据
+
+关节定义（需同步更新 modal.xacro）：
+    tray_joint  prismatic  沿 X 轴  range [0, 0.13]  (米)
+
+依赖：
+    unilabos/devices/ros_dev/simple_joint_publisher_node.py
+"""
+
+import asyncio
+import random
+import threading
+from typing import Dict, List, Optional
+
+import rclpy
+
+from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+try:
+    from pylabrobot.plate_reading.backend import PlateReaderBackend
+    from pylabrobot.resources.plate import Plate
+    from pylabrobot.resources.well import Well
+    _PLR_AVAILABLE = True
+except ImportError:
+    class PlateReaderBackend:  # type: ignore
+        async def setup(self): pass
+        async def stop(self): pass
+    Plate = object
+    Well = object
+    _PLR_AVAILABLE = False
+
+
+# 板托行程（米）
+_TRAY_OPEN  = 0.13   # 完全伸出
+_TRAY_CLOSE = 0.0    # 完全缩回（测量位）
+_TRAY_SPEED = 0.04   # m/s（50 Hz 下每帧 0.8 mm）
+
+# 模拟测量耗时（秒/孔）
+_READ_TIME_PER_WELL = 0.02
+
+
+class CLARIOstarPlusRvizBackend(PlateReaderBackend):
+    """
+    BMG CLARIOstar Plus 酶标仪仿真 Backend。
+
+    Parameters
+    ----------
+    device_id : str
+        与 URDF robot name 对应，默认 "bmg_labtech_clariostar_plus"。
+    """
+
+    def __init__(self, device_id: str = "bmg_labtech_clariostar_plus"):
+        if _PLR_AVAILABLE:
+            super().__init__()
+        self.device_id = device_id
+        self._tray_open: bool = True   # 初始状态：开（板托在外）
+
+        self._publisher: Optional[SimpleJointPublisher] = None
+        self._executor = None
+        self._executor_thread = None
+
+    # ------------------------------------------------------------------
+    # MachineBackend interface
+    # ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        if not rclpy.ok():
+            rclpy.init()
+
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=["tray_joint"],
+            rate=50,
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(
+            target=self._executor.spin, daemon=True
+        )
+        self._executor_thread.start()
+
+        # 初始状态：板托伸出（等待加板）
+        self._publisher.set_immediate({"tray_joint": _TRAY_OPEN})
+        self._tray_open = True
+        print(f"[{self.device_id}] Setup complete. Tray extended.")
+
+    async def stop(self) -> None:
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor_thread and self._executor_thread.is_alive():
+            self._executor.shutdown()
+        print(f"[{self.device_id}] Stopped.")
+
+    # ------------------------------------------------------------------
+    # PlateReaderBackend interface
+    # ------------------------------------------------------------------
+
+    async def open(self) -> None:
+        """板托伸出，等待放/取板。"""
+        if self._tray_open:
+            return
+        print(f"[{self.device_id}] Opening tray...")
+        await self._move_tray(_TRAY_OPEN)
+        self._tray_open = True
+        print(f"[{self.device_id}] Tray open.")
+
+    async def close(self, plate: Optional[object] = None) -> None:
+        """板托缩回，板进入测量腔。"""
+        if not self._tray_open:
+            return
+        print(f"[{self.device_id}] Closing tray...")
+        await self._move_tray(_TRAY_CLOSE)
+        self._tray_open = False
+        print(f"[{self.device_id}] Tray closed. Plate loaded.")
+
+    async def read_absorbance(
+        self, plate: object, wells: List[object], wavelength: int
+    ) -> List[Dict]:
+        """模拟吸光度测量，返回随机占位数据。"""
+        await self._run_measurement("absorbance", len(wells))
+        return [
+            {
+                "wavelength": wavelength,
+                "time": 0.0,
+                "temperature": 25.0,
+                "data": [[round(random.uniform(0.0, 2.0), 4) for _ in range(12)] for _ in range(8)],
+            }
+        ]
+
+    async def read_fluorescence(
+        self,
+        plate: object,
+        wells: List[object],
+        excitation_wavelength: int,
+        emission_wavelength: int,
+        focal_height: float,
+    ) -> List[Dict]:
+        """模拟荧光测量，返回随机占位数据。"""
+        await self._run_measurement("fluorescence", len(wells))
+        return [
+            {
+                "ex_wavelength": excitation_wavelength,
+                "em_wavelength": emission_wavelength,
+                "time": 0.0,
+                "temperature": 25.0,
+                "data": [[round(random.uniform(0.0, 65535.0), 1) for _ in range(12)] for _ in range(8)],
+            }
+        ]
+
+    async def read_luminescence(
+        self, plate: object, wells: List[object], focal_height: float
+    ) -> List[Dict]:
+        """模拟化学发光测量，返回随机占位数据。"""
+        await self._run_measurement("luminescence", len(wells))
+        return [
+            {
+                "time": 0.0,
+                "temperature": 25.0,
+                "data": [[round(random.uniform(0.0, 1e6), 1) for _ in range(12)] for _ in range(8)],
+            }
+        ]
+
+    def serialize(self) -> dict:
+        return {"type": self.__class__.__name__, "device_id": self.device_id}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _move_tray(self, target: float) -> None:
+        """异步包装板托平移动作。"""
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"tray_joint": target}, speed=_TRAY_SPEED),
+        )
+
+    async def _run_measurement(self, mode: str, num_wells: int) -> None:
+        """通用测量流程：关托 → 等待 → 开托。"""
+        await self.close()
+        duration = num_wells * _READ_TIME_PER_WELL
+        print(f"[{self.device_id}] Reading {mode} ({num_wells} wells, ~{duration:.1f}s)...")
+        await asyncio.sleep(duration)
+        await self.open()

--- a/unilabos/devices/ros_dev/simple_joint_publisher_node.py
+++ b/unilabos/devices/ros_dev/simple_joint_publisher_node.py
@@ -1,0 +1,126 @@
+"""
+SimpleJointPublisher — 通用单设备关节状态发布节点
+
+供 rviz_backend 系列仿真驱动使用。
+相比 LiquidHandlerJointPublisher，本节点功能更简单：
+- 不做逆运动学（IK），直接接受关节角度/位移目标值
+- 支持线性插值平滑运动（与液体处理站节点相同策略）
+- 不依赖 TfUpdate Action Server（适合独立设备仿真）
+
+用法示例：
+    publisher = SimpleJointPublisher(
+        device_id="bmg_labtech_clariostar_plus",
+        joint_names=["tray_joint"],
+        rate=50,
+    )
+    publisher.move_to({"tray_joint": 0.08}, speed=0.02)
+"""
+
+import copy
+import threading
+import time
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+class SimpleJointPublisher(Node):
+    """
+    通用关节状态发布器。
+
+    Parameters
+    ----------
+    device_id : str
+        设备 ID，也作为 ROS 节点名和关节名称前缀。
+    joint_names : list[str]
+        关节名称列表（不含前缀），例如 ["tray_joint", "lid_joint"]。
+    rate : int
+        发布频率（Hz），默认 50。
+    """
+
+    def __init__(self, device_id: str, joint_names: list[str], rate: int = 50):
+        super().__init__(device_id)
+
+        self.device_id = device_id
+        self.rate = rate
+        self._lock = threading.Lock()
+
+        prefixed = [f"{device_id}_{name}" for name in joint_names]
+        self._j_msg = JointState(
+            name=prefixed,
+            position=[0.0] * len(joint_names),
+            velocity=[0.0] * len(joint_names),
+            effort=[0.0] * len(joint_names),
+        )
+        self._joint_index = {name: i for i, name in enumerate(joint_names)}
+
+        self._pub = self.create_publisher(JointState, "/joint_states", 10)
+        self.create_timer(1.0 / rate, self._publish_callback)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def move_to(self, targets: dict[str, float], speed: float = 0.05) -> None:
+        """
+        将指定关节平滑插值运动到目标位置。
+
+        Parameters
+        ----------
+        targets : dict[str, float]
+            {关节名: 目标位置（弧度 or 米）}，关节名不含设备前缀。
+        speed : float
+            每帧最大步长（弧度/米），默认 0.05。
+        """
+        target_positions = copy.deepcopy(self._j_msg.position)
+        for name, value in targets.items():
+            idx = self._joint_index.get(name)
+            if idx is None:
+                self.get_logger().warn(f"Unknown joint: {name}")
+                continue
+            target_positions[idx] = value
+
+        self._interpolate_to(target_positions, speed)
+
+    def set_immediate(self, targets: dict[str, float]) -> None:
+        """直接跳变到目标位置，不做插值（用于初始化/复位）。"""
+        with self._lock:
+            for name, value in targets.items():
+                idx = self._joint_index.get(name)
+                if idx is not None:
+                    self._j_msg.position[idx] = value
+
+    def get_position(self, joint_name: str) -> float:
+        """获取指定关节当前位置。"""
+        idx = self._joint_index.get(joint_name)
+        if idx is None:
+            raise KeyError(f"Unknown joint: {joint_name}")
+        return self._j_msg.position[idx]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _interpolate_to(self, target: list[float], speed: float) -> None:
+        """线性插值运动循环，阻塞直到到达目标。"""
+        dt = 1.0 / self.rate
+        while True:
+            done = 0
+            with self._lock:
+                current = list(self._j_msg.position)
+                for i, tgt in enumerate(target):
+                    dist = tgt - current[i]
+                    if abs(dist) <= speed * dt:
+                        self._j_msg.position[i] = tgt
+                        done += 1
+                    else:
+                        self._j_msg.position[i] += (dist / abs(dist)) * speed * dt
+            if done == len(target):
+                break
+            time.sleep(dt)
+
+    def _publish_callback(self) -> None:
+        with self._lock:
+            self._j_msg.header.stamp = self.get_clock().now().to_msg()
+            self._pub.publish(self._j_msg)

--- a/unilabos/devices/sealer/a4s_rviz_backend.py
+++ b/unilabos/devices/sealer/a4s_rviz_backend.py
@@ -1,0 +1,183 @@
+"""
+Brooks / Azenta a4S 封膜机仿真 RViz Backend
+
+设备功能：自动封膜机（热压贴膜密封微孔板）
+模型完整度：⭐⭐⭐ — 单体 mesh + socketTypeGenericSbsFootprint。
+
+仿真逻辑（两关节）：
+  feed_joint   prismatic  沿 Y 轴  [0, 0.146]  — 板水平推入
+  press_joint  prismatic  沿 Z 轴  [0, -0.05]  — 加热压盘下压封膜
+
+封膜流程：
+  1. open()  → feed_joint = 0（等待放板）
+  2. seal(temperature, duration)
+            → close（推板入）
+            → press_joint 下压
+            → 停留 duration 秒（热压）
+            → press_joint 抬起
+            → feed_joint 退出
+
+关节定义（需同步更新 modal.xacro）：
+    feed_joint   prismatic  Y  [0, 0.146]
+    press_joint  prismatic  Z  [0, -0.05]
+
+依赖：
+    unilabos/devices/ros_dev/simple_joint_publisher_node.py
+"""
+
+import asyncio
+import threading
+from typing import Optional
+
+import rclpy
+
+from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+try:
+    from pylabrobot.sealing.backend import SealerBackend
+    _PLR_AVAILABLE = True
+except ImportError:
+    class SealerBackend:  # type: ignore
+        async def setup(self): pass
+        async def stop(self): pass
+    _PLR_AVAILABLE = False
+
+
+# 行程参数（米）
+_FEED_INSERT  = 0.146   # 板完全推入（与 XACRO socket 坐标对应）
+_FEED_HOME    = 0.0
+_PRESS_DOWN   = -0.05   # 压盘下压行程
+_PRESS_UP     = 0.0
+_FEED_SPEED   = 0.04    # m/s
+_PRESS_SPEED  = 0.008   # m/s（缓慢下压模拟热压）
+
+
+class A4SSealerRvizBackend(SealerBackend):
+    """
+    Brooks a4S 封膜机仿真 Backend。
+
+    Parameters
+    ----------
+    device_id : str
+        与 URDF robot name 对应，默认 "brooks_a4ssealer"。
+    """
+
+    def __init__(self, device_id: str = "brooks_a4ssealer"):
+        if _PLR_AVAILABLE:
+            super().__init__()
+        self.device_id = device_id
+        self._target_temperature: float = 170.0  # °C，典型封膜温度
+        self._current_temperature: float = 22.0
+        self._tray_open: bool = True
+
+        self._publisher: Optional[SimpleJointPublisher] = None
+        self._executor = None
+        self._executor_thread = None
+
+    # ------------------------------------------------------------------
+    # MachineBackend interface
+    # ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        if not rclpy.ok():
+            rclpy.init()
+
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=["feed_joint", "press_joint"],
+            rate=50,
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(
+            target=self._executor.spin, daemon=True
+        )
+        self._executor_thread.start()
+
+        self._publisher.set_immediate({"feed_joint": _FEED_HOME, "press_joint": _PRESS_UP})
+        self._tray_open = True
+        print(f"[{self.device_id}] Setup complete. Ready for plate.")
+
+    async def stop(self) -> None:
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor_thread and self._executor_thread.is_alive():
+            self._executor.shutdown()
+        print(f"[{self.device_id}] Stopped.")
+
+    # ------------------------------------------------------------------
+    # SealerBackend interface
+    # ------------------------------------------------------------------
+
+    async def open(self) -> None:
+        """板托退出，等待放/取板。"""
+        if self._tray_open:
+            return
+        loop = asyncio.get_event_loop()
+        print(f"[{self.device_id}] Opening (feeding plate out)...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"feed_joint": _FEED_HOME}, speed=_FEED_SPEED),
+        )
+        self._tray_open = True
+        print(f"[{self.device_id}] Tray open.")
+
+    async def close(self) -> None:
+        """推板入封膜腔。"""
+        if not self._tray_open:
+            return
+        loop = asyncio.get_event_loop()
+        print(f"[{self.device_id}] Feeding plate in...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"feed_joint": _FEED_INSERT}, speed=_FEED_SPEED),
+        )
+        self._tray_open = False
+        print(f"[{self.device_id}] Plate loaded.")
+
+    async def seal(self, temperature: int, duration: float) -> None:
+        """
+        执行封膜流程。
+
+        Parameters
+        ----------
+        temperature : int
+            封膜温度（°C），典型值 160–180°C。
+        duration : float
+            热压持续时间（秒），典型值 1.0–3.0s。
+        """
+        loop = asyncio.get_event_loop()
+
+        await self.set_temperature(float(temperature))
+        await self.close()
+
+        # 压盘下压
+        print(f"[{self.device_id}] Pressing at {temperature}°C for {duration}s...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"press_joint": _PRESS_DOWN}, speed=_PRESS_SPEED),
+        )
+
+        # 热压停顿
+        await asyncio.sleep(duration)
+
+        # 压盘抬起
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"press_joint": _PRESS_UP}, speed=_PRESS_SPEED),
+        )
+
+        await self.open()
+        print(f"[{self.device_id}] Seal complete.")
+
+    async def set_temperature(self, temperature: float) -> None:
+        self._target_temperature = temperature
+        print(f"[{self.device_id}] Set temperature → {temperature}°C (simulated).")
+
+    async def get_temperature(self) -> float:
+        diff = self._target_temperature - self._current_temperature
+        self._current_temperature += min(abs(diff), 5.0) * (1 if diff > 0 else -1)
+        return round(self._current_temperature, 1)
+
+    def serialize(self) -> dict:
+        return {"type": self.__class__.__name__, "device_id": self.device_id}

--- a/unilabos/devices/xpeel/xpeel_rviz_backend.py
+++ b/unilabos/devices/xpeel/xpeel_rviz_backend.py
@@ -1,0 +1,161 @@
+"""
+Brooks / Azenta XPeel 仿真 RViz Backend
+
+设备功能：自动揭膜机（高速去除微孔板密封膜）
+模型完整度：⭐⭐⭐ — 单体 mesh + socketTypeGenericSbsFootprint（板位坐标）。
+
+仿真逻辑（两关节）：
+  feed_joint   prismatic  沿 Y 轴  [0, 0.29]  — 板水平推入机器
+  peel_joint   prismatic  沿 Z 轴  [0, -0.02] — 揭膜头垂直下压
+
+完整揭膜流程：
+  1. open()   → feed_joint = 0（板托归位/等待）
+  2. peel()   → feed_joint 推入 → peel_joint 下压 → 停顿 → peel_joint 回 → feed_joint 退出
+
+关节定义（需同步更新 modal.xacro）：
+    feed_joint  prismatic  Y  [0, 0.29]
+    peel_joint  prismatic  Z  [0, -0.02]
+
+依赖：
+    unilabos/devices/ros_dev/simple_joint_publisher_node.py
+"""
+
+import asyncio
+import threading
+from typing import Optional
+
+import rclpy
+
+from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+try:
+    from pylabrobot.peeling.backend import PeelerBackend
+    _PLR_AVAILABLE = True
+except ImportError:
+    class PeelerBackend:  # type: ignore
+        async def setup(self): pass
+        async def stop(self): pass
+    _PLR_AVAILABLE = False
+
+
+# 行程参数（米）
+_FEED_INSERT = 0.29    # 板完全推入
+_FEED_HOME   = 0.0     # 板托归位
+_PEEL_DOWN   = -0.02   # 揭膜头下压量
+_PEEL_UP     = 0.0     # 揭膜头抬起
+_FEED_SPEED  = 0.05    # m/s
+_PEEL_SPEED  = 0.005   # m/s（缓慢下压，模拟撕膜力）
+
+# 撕膜停留时间（秒）
+_PEEL_DWELL  = 1.5
+
+
+class XPeelRvizBackend(PeelerBackend):
+    """
+    Brooks XPeel 揭膜机仿真 Backend。
+
+    Parameters
+    ----------
+    device_id : str
+        与 URDF robot name 对应，默认 "brooks_xpeel"。
+    """
+
+    def __init__(self, device_id: str = "brooks_xpeel"):
+        if _PLR_AVAILABLE:
+            super().__init__()
+        self.device_id = device_id
+
+        self._publisher: Optional[SimpleJointPublisher] = None
+        self._executor = None
+        self._executor_thread = None
+
+    # ------------------------------------------------------------------
+    # MachineBackend interface
+    # ------------------------------------------------------------------
+
+    async def setup(self) -> None:
+        if not rclpy.ok():
+            rclpy.init()
+
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=["feed_joint", "peel_joint"],
+            rate=50,
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(
+            target=self._executor.spin, daemon=True
+        )
+        self._executor_thread.start()
+
+        # 初始化：板托在外，揭膜头抬起
+        self._publisher.set_immediate({"feed_joint": _FEED_HOME, "peel_joint": _PEEL_UP})
+        print(f"[{self.device_id}] Setup complete. Ready for plate.")
+
+    async def stop(self) -> None:
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor_thread and self._executor_thread.is_alive():
+            self._executor.shutdown()
+        print(f"[{self.device_id}] Stopped.")
+
+    # ------------------------------------------------------------------
+    # PeelerBackend interface
+    # ------------------------------------------------------------------
+
+    async def peel(self) -> None:
+        """
+        执行完整揭膜流程：
+        1. 推板入机
+        2. 揭膜头下压
+        3. 保持停顿（撕膜）
+        4. 揭膜头抬起
+        5. 板退出
+        """
+        loop = asyncio.get_event_loop()
+
+        # Step 1: 推板入机
+        print(f"[{self.device_id}] [1/4] Feeding plate in...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"feed_joint": _FEED_INSERT}, speed=_FEED_SPEED),
+        )
+
+        # Step 2: 揭膜头下压
+        print(f"[{self.device_id}] [2/4] Peeling head pressing down...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to({"peel_joint": _PEEL_DOWN}, speed=_PEEL_SPEED),
+        )
+
+        # Step 3: 撕膜停顿
+        print(f"[{self.device_id}] [3/4] Holding for peel ({_PEEL_DWELL}s)...")
+        await asyncio.sleep(_PEEL_DWELL)
+
+        # Step 4: 揭膜头抬起
+        print(f"[{self.device_id}] [4/4] Peeling head lifting and plate exiting...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"peel_joint": _PEEL_UP, "feed_joint": _FEED_HOME},
+                speed=_FEED_SPEED,
+            ),
+        )
+        print(f"[{self.device_id}] Peel complete.")
+
+    async def restart(self) -> None:
+        """复位所有关节到初始位置。"""
+        loop = asyncio.get_event_loop()
+        print(f"[{self.device_id}] Restarting (homing)...")
+        await loop.run_in_executor(
+            None,
+            lambda: self._publisher.move_to(
+                {"feed_joint": _FEED_HOME, "peel_joint": _PEEL_UP},
+                speed=_FEED_SPEED,
+            ),
+        )
+        print(f"[{self.device_id}] Restart complete.")
+
+    def serialize(self) -> dict:
+        return {"type": self.__class__.__name__, "device_id": self.device_id}


### PR DESCRIPTION
## Summary
- Add RViz simulation backends for non-liquid-handling devices, mirroring the existing `liquid_handling/rviz_backend.py` (`UniLiquidHandlerRvizBackend`) pattern.
- Introduce a shared `SimpleJointPublisher` ROS2 node that publishes `/joint_states` so device backends can drive URDF/xacro joint motion in RViz.

### New files (7, +1286 lines)
- `unilabos/devices/ros_dev/simple_joint_publisher_node.py` — shared joint publisher (linear-interpolated motion, no IK)
- `unilabos/devices/cytomat/liconic_stx110_rviz_backend.py` — LiCONiC STX110 carousel rotation
- `unilabos/devices/cytomat/thermo_cytomat2c_rviz_backend.py` — Thermo Cytomat 2C front/rear doors
- `unilabos/devices/heaterstirrer/qinstruments_bioshake_rviz_backend.py` — QInstruments BioShake orbital shake
- `unilabos/devices/platereader/clariostar_rviz_backend.py` — BMG CLARIOstar tray in/out + mock reads
- `unilabos/devices/xpeel/xpeel_rviz_backend.py` — Brooks XPeel feed + peel
- `unilabos/devices/sealer/a4s_rviz_backend.py` — Brooks a4S feed + press

### Design notes
- Each backend subclasses the matching PyLabRobot backend (Shaker/HeaterShaker, PlateReader, Peeler, Sealer); PLR imports are guarded so the modules import even without pylabrobot installed.
- Backends translate PLR high-level ops (shake/open/close/peel/seal/load_plate) into joint targets via `SimpleJointPublisher`, same as the liquid handler simulation path.

### Scope / follow-ups
- This PR only adds the backend modules. They are **not yet wired** into device classes (`simulator=True` instantiation) or `registry/devices/*.yaml`, and per-device `joint_config` + URDF still need to be hooked up before they are driven end-to-end. Follow-up PR will add the wiring.

## Test plan
- [ ] Import smoke test: `python -c "import unilabos.devices.ros_dev.simple_joint_publisher_node"` and each backend module.
- [ ] With a ROS2 env, instantiate a backend, call `setup()`, trigger an op, and confirm `/joint_states` updates drive the model in RViz.

Made with [Cursor](https://cursor.com)