### PR TITLE
feat(sim): STX110 full-stack sim demo + M-3 real download (Plan 08v2/09)

### DIFF
--- a/scripts/smoke_stx110_sim.py
+++ b/scripts/smoke_stx110_sim.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""CP1 smoke: 走真实 initialize_device 路径验证 08 sim 替换 + action 驱动。
+
+incubator.liconic_stx110 (real) --sim--> VirtualLiconicStx110 (virtual)，
+经 ros2_device_node 实例化为真实设备节点，driver.load_plate 驱动 /joint_states。
+"""
+import asyncio
+import math
+import sys
+
+
+def main() -> int:
+    import rclpy
+
+    if not rclpy.ok():
+        rclpy.init()
+
+    from unilabos.registry.registry import build_registry, lab_registry
+    from unilabos.registry import pair_registry
+    from unilabos.resources.resource_tracker import ResourceDictInstance
+    from unilabos.ros.initialize_device import initialize_device_from_dict
+    from unilabos.sim.context import RuntimeContext
+    from unilabos.devices.virtual.virtual_liconic_stx110 import VirtualLiconicStx110
+
+    print("== build_registry ==")
+    build_registry()
+    pair_registry.reset_pair_registry()
+    pe = pair_registry.lookup("incubator.liconic_stx110")
+    assert pe.virtual == "virtual_liconic_stx110", pe
+    print(f"[08] pair: {pe.real} -> {pe.virtual}  engine={pe.engine}  observed={pe.twin_observed}")
+    assert "virtual_liconic_stx110" in lab_registry.device_type_registry, "virtual class not registered"
+
+    dc = ResourceDictInstance.get_resource_instance_from_dict({
+        "name": "liconic_stx110",
+        "type": "device",
+        "class": "incubator.liconic_stx110",
+        "config": {"target_temperature": 37.0},
+    })
+    print("== initialize_device_from_dict (mode=sim) ==")
+    node = initialize_device_from_dict("liconic_stx110", dc, runtime=RuntimeContext(mode="sim"))
+    assert node is not None, "node is None"
+    driver = getattr(node, "driver_instance", None)
+    assert isinstance(driver, VirtualLiconicStx110), f"driver is {type(driver)}"
+    print(f"[sim] real incubator.liconic_stx110 -> {type(driver).__name__}  (真实替换 OK)")
+
+    print("== driver.initialize (起关节发布器) ==")
+    driver.initialize()
+
+    async def seq():
+        for s in [1, 3, 5, 2]:
+            await driver.load_plate(s)
+            ang = round(math.degrees(driver._carousel_angle), 1)
+            print(f"  load_plate({s}) -> carousel_angle={ang}°  data.status={driver.data.get('status')}")
+            assert abs(ang - (s - 1) * 72) < 0.5, f"angle mismatch slot {s}: {ang}"
+            await asyncio.sleep(0.2)
+    asyncio.run(seq())
+
+    print("\n== CP1 GREEN: 08 替换 + initialize_device + load_plate 全通 ==")
+    driver.cleanup()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_policies.py
+++ b/scripts/verify_policies.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""验证:① generated device_pair.yaml 的 Phase 1A 兼容;② 无 virtual 时 stub/skip/fail 在 Edge 生效。"""
+import rclpy
+
+if not rclpy.ok():
+    rclpy.init()
+
+from pathlib import Path
+
+from unilabos.registry.registry import build_registry
+from unilabos.registry import pair_registry
+from unilabos.registry.pair_registry import PairRegistry
+from unilabos.resources.resource_tracker import ResourceDictInstance
+from unilabos.ros.initialize_device import initialize_device_from_dict, MissingVirtualDeviceError
+from unilabos.sim.context import RuntimeContext
+
+print("== build_registry ==")
+build_registry()
+
+# ---------- 第1部分:generated yaml 的 Phase 1A 兼容 ----------
+gen = Path.home() / "dev/Uni-Lab-OS/unilabos_data/simulation_pairs/device_pair.generated.yaml"
+print(f"\n[1] generated yaml: {gen}  exists={gen.exists()}")
+if gen.exists():
+    pr = PairRegistry(path=str(gen))  # 用 Phase 1A 同款 PairRegistry 解析
+    pe = pr.lookup("incubator.liconic_stx110")
+    print(f"[1] PairRegistry.lookup -> real={pe.real} virtual={pe.virtual} engine={pe.engine} "
+          f"observed={pe.twin_observed}  => Phase 1A 兼容(同一 PairEntry)")
+
+# ---------- 第2部分:stub/skip/fail 在 Edge 生效 ----------
+pair_registry.reset_pair_registry()  # 用仓库默认 device_pair.yaml
+
+def mk(cls):
+    return ResourceDictInstance.get_resource_instance_from_dict(
+        {"name": "d", "type": "device", "class": cls, "config": {}}
+    )
+
+print("\n[2] sim 模式下无 virtual 的策略:")
+# stub:未配对的真实类 → 默认 policy=stub → NullDeviceStub 节点
+n = initialize_device_from_dict("d_stub", mk("some.unknown.real.device"), runtime=RuntimeContext(mode="sim"))
+drv = type(getattr(n, "driver_instance", None)).__name__ if n else None
+print(f"  stub  (some.unknown.real.device) -> node driver = {drv}  (期望 NullDeviceStub)")
+
+# skip:device_pair.yaml 里 cameracontroller_device: virtual=null, policy=skip → 返回 None
+n = initialize_device_from_dict("d_skip", mk("cameracontroller_device"), runtime=RuntimeContext(mode="sim"))
+print(f"  skip  (cameracontroller_device)  -> node = {n}  (期望 None)")
+
+# fail:device_pair.yaml 里 Qone_nmr: virtual=null, policy=fail → 抛 MissingVirtualDeviceError
+try:
+    initialize_device_from_dict("d_fail", mk("Qone_nmr"), runtime=RuntimeContext(mode="sim"))
+    print("  fail  (Qone_nmr)                 -> 没抛异常 ❌")
+except MissingVirtualDeviceError:
+    print("  fail  (Qone_nmr)                 -> MissingVirtualDeviceError ✅ (期望抛)")
+
+print("\n== 验证完成 ==")

--- a/tests/integration/test_m3_real_download.py
+++ b/tests/integration/test_m3_real_download.py
@@ -1,0 +1,105 @@
+"""M-3 真远程下载验证(不 mock fetch / 不 monkeypatch extract)。
+
+造一个真实 tar.gz 虚拟包(含 pyproject.toml + unilabos_registry/),用本地 HTTP server
+托管,构造带 download_url + 真 sha256 的 PairBundle,跑 make_downloader 的默认 fetch,
+真正走 community_packages._download_and_extract_package 的 下载→sha256 校验→解压→挂载 全链路。
+"""
+
+import functools
+import hashlib
+import http.server
+import socketserver
+import tarfile
+import threading
+from pathlib import Path
+
+from unilabos.sim.pairs.bundle import parse_bundle
+from unilabos.sim.pairs.download import make_downloader
+
+
+def _build_pkg_targz(dst: Path) -> Path:
+    """造一个最小合法虚拟包(pyproject + unilabos_registry/),打成 tar.gz。"""
+    src = dst / "pkgsrc"
+    (src / "unilabos_registry" / "devices").mkdir(parents=True)
+    (src / "pyproject.toml").write_text(
+        "[project]\nname = \"m3-virtual-pkg\"\nversion = \"0.1.0\"\n\n"
+        "[tool.unilabos.registry]\npaths = [\"unilabos_registry\"]\n",
+        encoding="utf-8",
+    )
+    (src / "unilabos_registry" / "devices" / "v.yaml").write_text(
+        "m3.virtual.demo:\n  class:\n    module: x:Y\n    type: python\n", encoding="utf-8"
+    )
+    archive = dst / "m3-virtual-pkg-0.1.0.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(src, arcname="m3-virtual-pkg-0.1.0")
+    return archive
+
+
+def _serve(directory: Path):
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    return httpd, port
+
+
+def _bundle(download_url: str, sha256: str) -> dict:
+    return {
+        "bundle_version": "2026-06-24T00:00:00Z",
+        "engine": "custom",
+        "pairs": [
+            {
+                "real": "m3.real.demo",
+                "engine": "custom",
+                "virtual": "community.m3.virtual.demo",
+                "missing_sim_policy": "stub",
+                "is_default": True,
+                "priority": 100,
+                "twin_capability": {"enabled": False},
+                "virtual_package": {
+                    "normalized_name": "m3-virtual-pkg",
+                    "version": "0.1.0",
+                    "download_url": download_url,
+                    "sha256": sha256,
+                    "class_namespace": "community.m3",
+                },
+            }
+        ],
+        "warnings": [],
+    }
+
+
+def test_m3_real_http_download_and_extract(tmp_path):
+    archive = _build_pkg_targz(tmp_path)
+    sha = "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest()
+    httpd, port = _serve(tmp_path)
+    try:
+        url = f"http://127.0.0.1:{port}/{archive.name}"
+        bundle = parse_bundle(_bundle(url, sha))
+        work = tmp_path / "work"
+        work.mkdir()
+        out = make_downloader(http_client=None, working_dir=str(work))(bundle)
+
+        assert len(out) == 1, out
+        pkg_dir = Path(out[0])
+        assert pkg_dir.is_dir()
+        assert (pkg_dir / "pyproject.toml").is_file()
+        assert (pkg_dir / "unilabos_registry" / "devices" / "v.yaml").is_file()
+    finally:
+        httpd.shutdown()
+
+
+def test_m3_real_sha256_mismatch_is_isolated(tmp_path):
+    archive = _build_pkg_targz(tmp_path)
+    httpd, port = _serve(tmp_path)
+    try:
+        url = f"http://127.0.0.1:{port}/{archive.name}"
+        bundle = parse_bundle(_bundle(url, "sha256:deadbeef"))  # 故意错的 sha256
+        work = tmp_path / "work"
+        work.mkdir()
+        out = make_downloader(http_client=None, working_dir=str(work))(bundle)
+        # sha256 不匹配 → 该包失败被隔离,返回空(不抛)
+        assert out == []
+    finally:
+        httpd.shutdown()

--- a/unilabos/devices/ros_dev/simple_joint_publisher_node.py
+++ b/unilabos/devices/ros_dev/simple_joint_publisher_node.py
@@ -39,8 +39,8 @@ class SimpleJointPublisher(Node):
         发布频率（Hz），默认 50。
     """
 
-    def __init__(self, device_id: str, joint_names: list[str], rate: int = 50):
-        super().__init__(device_id)
+    def __init__(self, device_id: str, joint_names: list[str], rate: int = 50, node_name=None):
+        super().__init__(node_name or device_id)
 
         self.device_id = device_id
         self.rate = rate

--- a/unilabos/devices/virtual/virtual_liconic_stx110.py
+++ b/unilabos/devices/virtual/virtual_liconic_stx110.py
@@ -1,0 +1,193 @@
+"""
+VirtualLiconicStx110 — LiCONiC STX110 转盘孵育器仿真驱动（RViz 引擎适配）。
+
+08v2 sim 替换的虚拟驱动：sim 模式下替换真实设备 incubator.liconic_stx110。
+通过 SimpleJointPublisher 发布 /joint_states 驱动 RViz 中转盘（0_carousel_joint）旋转，
+模拟 5 个货架（72° 间隔）的存/取板动作。
+
+自标记（M-8 / 08v2）：
+  driver_runtime_kind = virtual
+  virtual_driver_kind = engine_adapter
+  sim_engine          = rviz
+"""
+
+import asyncio
+import logging
+import math
+import threading
+from typing import Any, Dict, Optional
+
+from unilabos.registry.decorators import action, device, not_action
+from unilabos.ros.nodes.base_device_node import BaseROS2DeviceNode
+
+# 5 个货架角度（弧度），从正前方逆时针，间隔 72°
+_SLOT_ANGLES = {i: math.radians((i - 1) * 72) for i in range(1, 6)}
+_TRANSFER_ANGLE = 0.0  # 出口/传输窗口角度
+_CAROUSEL_SPEED = 0.8  # rad/s
+_CAROUSEL_JOINT = "0_carousel_joint"
+
+
+@device(
+    id="virtual_liconic_stx110",
+    display_name="STX110 转盘孵育器(仿真/RViz)",
+    category=["virtual_device"],
+    description="LiCONiC STX110 carousel incubator simulation driving the RViz carousel joint.",
+    driver_runtime_kind="virtual",
+    virtual_driver_kind="engine_adapter",
+    sim_engine="rviz",
+)
+class VirtualLiconicStx110:
+    """STX110 孵育器仿真：在 RViz 中驱动转盘旋转，模拟板的存取。"""
+
+    _ros_node: BaseROS2DeviceNode
+
+    def __init__(
+        self,
+        device_id: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        """
+        初始化虚拟 STX110。
+
+        Args:
+            device_id[设备ID]: 设备实例 ID，默认 liconic_stx110，须与 URDF 关节前缀一致。
+            config[设备配置]: 可含 target_temperature。
+        """
+        if device_id is None and "id" in kwargs:
+            device_id = kwargs.pop("id")
+        if config is None and "config" in kwargs:
+            config = kwargs.pop("config")
+
+        self.device_id = device_id or "liconic_stx110"
+        self.config = config or {}
+        self.logger = logging.getLogger(f"VirtualLiconicStx110.{self.device_id}")
+        self.data: Dict[str, Any] = {}
+
+        self._target_temperature = float(self.config.get("target_temperature", 37.0))
+        self._current_temperature = 22.0
+        self._carousel_angle = _TRANSFER_ANGLE
+
+        self._publisher = None
+        self._executor = None
+        self._executor_thread = None
+
+        for key, value in kwargs.items():
+            if not hasattr(self, key):
+                setattr(self, key, value)
+
+        self.logger.info(f"=== 虚拟 STX110 孵育器 {self.device_id} 已创建 ===")
+
+    @not_action
+    def post_init(self, ros_node: BaseROS2DeviceNode):
+        self._ros_node = ros_node
+
+    @not_action
+    def _ensure_publisher(self) -> None:
+        """懒加载关节发布器（整机内设备节点不保证自动调 initialize）。"""
+        if self._publisher is not None:
+            return
+        import rclpy
+
+        from unilabos.devices.ros_dev.simple_joint_publisher_node import SimpleJointPublisher
+
+        if not rclpy.ok():
+            rclpy.init()
+        # 独立节点名，避免与设备 ROS 节点（名为 device_id）重名
+        self._publisher = SimpleJointPublisher(
+            device_id=self.device_id,
+            joint_names=[_CAROUSEL_JOINT],
+            rate=50,
+            node_name=f"{self.device_id}_carousel_pub",
+        )
+        self._executor = rclpy.executors.MultiThreadedExecutor()
+        self._executor.add_node(self._publisher)
+        self._executor_thread = threading.Thread(target=self._executor.spin, daemon=True)
+        self._executor_thread.start()
+        self._publisher.set_immediate({_CAROUSEL_JOINT: self._carousel_angle})
+        self.logger.info(f"STX110 {self.device_id} 关节发布器已启动。")
+
+    @not_action
+    def initialize(self) -> bool:
+        """启动关节发布器并复位转盘到出口位置。"""
+        self._carousel_angle = _TRANSFER_ANGLE
+        self._ensure_publisher()
+        self.data.update(
+            {
+                "status": "Ready",
+                "carousel_angle": 0.0,
+                "slot": None,
+                "temperature": self._current_temperature,
+            }
+        )
+        self.logger.info(f"STX110 {self.device_id} 初始化完成，转盘在出口位置。")
+        return True
+
+    @not_action
+    def cleanup(self) -> bool:
+        if self._executor and self._publisher:
+            self._executor.remove_node(self._publisher)
+        if self._executor:
+            self._executor.shutdown()
+        self.data.update({"status": "Offline"})
+        self.logger.info(f"STX110 {self.device_id} 已清理。")
+        return True
+
+    async def _rotate_to(self, angle: float) -> None:
+        # move_to 为阻塞插值循环；整机 action 执行上下文无运行中的 asyncio loop，直接阻塞调用。
+        self._ensure_publisher()
+        self._publisher.move_to({_CAROUSEL_JOINT: angle}, _CAROUSEL_SPEED)
+        self._carousel_angle = angle
+        self.data["carousel_angle"] = round(math.degrees(angle), 1)
+
+    @action(description="存板：转盘旋转使指定货架对准传输窗口")
+    async def load_plate(self, slot: int = 1) -> bool:
+        """
+        将转盘旋转使 slot 对准传输窗口，模拟放板。
+
+        Args:
+            slot[货架编号]: 目标货架 1–5。
+        """
+        slot = int(slot)
+        if slot not in _SLOT_ANGLES:
+            self.data.update({"status": f"Error: invalid slot {slot}"})
+            return False
+        angle = _SLOT_ANGLES[slot]
+        self.data.update({"status": f"Loading slot {slot}", "slot": slot})
+        self.logger.info(f"转盘 → 货架 {slot} ({math.degrees(angle):.0f}°)")
+        await self._rotate_to(angle)
+        self.data.update({"status": f"Slot {slot} aligned"})
+        return True
+
+    @action(description="取板：转盘旋转到指定货架取出后回到出口")
+    async def unload_plate(self, slot: int = 1) -> bool:
+        """
+        旋转转盘取出指定 slot 的板，随后回到出口。
+
+        Args:
+            slot[货架编号]: 目标货架 1–5。
+        """
+        slot = int(slot)
+        if slot not in _SLOT_ANGLES:
+            self.data.update({"status": f"Error: invalid slot {slot}"})
+            return False
+        angle = _SLOT_ANGLES[slot]
+        self.data.update({"status": f"Unloading slot {slot}", "slot": slot})
+        self.logger.info(f"转盘 → 货架 {slot} 取板 ({math.degrees(angle):.0f}°)")
+        await self._rotate_to(angle)
+        await self._rotate_to(_TRANSFER_ANGLE)
+        self.data.update({"status": "At transfer", "slot": None})
+        return True
+
+    @action(description="设置孵育温度（仿真，无运动）")
+    async def set_temperature(self, temperature: float = 37.0) -> bool:
+        """
+        设置目标孵育温度。
+
+        Args:
+            temperature[目标温度]: 摄氏度。
+        """
+        self._target_temperature = float(temperature)
+        self.data.update({"temperature": self._target_temperature})
+        self.logger.info(f"设置温度 → {temperature}°C（仿真）")
+        return True

--- a/unilabos/registry/device_pair.yaml
+++ b/unilabos/registry/device_pair.yaml
@@ -1,4 +1,11 @@
 pairs:
+  - real: incubator.liconic_stx110
+    virtual: virtual_liconic_stx110
+    engine: rviz
+    twin_capability:
+      enabled: true
+      observed: [carousel_angle, temperature, status]
+      throttle_hz: 5
   - real: heaterstirrer.dalong
     virtual: virtual_heatchill
     twin_observed: [temperature, rpm, status]

--- a/unilabos/registry/devices/incubator.yaml
+++ b/unilabos/registry/devices/incubator.yaml
@@ -1,0 +1,16 @@
+incubator.liconic_stx110:
+  category:
+  - incubator
+  - storage
+  class:
+    action_value_mappings: {}
+    module: unilabos.devices.virtual.virtual_liconic_stx110:VirtualLiconicStx110
+    status_types:
+      status: str
+    type: python
+  config_info: []
+  description: LiCONiC STX110 转盘式板存储孵育器（真实设备模板，用于 Plan 08 v2 仿真配对解析）。
+  handles: []
+  icon: ''
+  init_param_schema: {}
+  version: 1.0.0

--- a/unilabos/test/experiments/stx110_sim.json
+++ b/unilabos/test/experiments/stx110_sim.json
@@ -1,0 +1,16 @@
+{
+    "nodes": [
+        {
+            "id": "liconic_stx110",
+            "name": "STX110 转盘孵育器",
+            "children": [],
+            "parent": null,
+            "type": "device",
+            "class": "incubator.liconic_stx110",
+            "position": {"x": 400, "y": 300, "z": 0},
+            "config": {"target_temperature": 37.0},
+            "data": {"status": "Ready"}
+        }
+    ],
+    "links": []
+}


### PR DESCRIPTION
## Summary
- **STX110 full-stack sim demo**: `VirtualLiconicStx110` `@device` driver (self-marks `driver_runtime_kind=virtual` / `virtual_driver_kind=engine_adapter` / `sim_engine=rviz`; `@action` load_plate/unload_plate/set_temperature auto-generate action mappings via AST scan); real `incubator.liconic_stx110` template (dotted id via YAML); 08v2 `device_pair.yaml` pair (engine + twin_capability); minimal graph + CP1 smoke.
- `SimpleJointPublisher`: add `node_name` param (avoid clashing with the device ROS node inside the full stack).
- **M-3 real virtual-package download** integration test: real tar.gz over local HTTP -> download -> sha256 verify -> extract -> mount (+ sha256-mismatch isolation). Closes the M-3 real-download gap (no mock).
- 08v2 acceptance verify script (`scripts/verify_policies.py`): bundle->generated yaml Phase-1A compat; stub/skip/fail edge effect.

## End-to-end validation (test backend + 4090 unilab, py3.11)
- `unilab --mode sim` full stack: local (fallback device_pair) + **cloud** (testlab2 `resolve`, `engine=custom`) -> 08 device_pair swap (`[sim] incubator.liconic_stx110 -> virtual_liconic_stx110`) -> `ros2 action load_plate` -> RViz carousel rotates.
- §15-3 (bundle -> Phase-1A yaml) and §15-4 (stub/skip/fail visible in cloud + effective on edge) verified live.
- `tests/sim/pairs` + `tests/registry` = 79 passed; integration (variant construction / local sim replacement / external full-chain / M-3 download) green.

## Notes
- Rebased clean onto latest `lab_2_isacc_sim` (auto-mergeable). The earlier 08v2/09 follow-ups (B-H + ext-registry) are already merged via prior PRs; this PR adds only the genuinely-new STX110 demo + M-3 test.
- Design docs live in the parent LeapLab repo (separate).

Made with [Cursor](https://cursor.com)